### PR TITLE
冗長なPHPDocコメントを削除しコードを整理

### DIFF
--- a/Bundle/CustomerGroupRankBundle.php
+++ b/Bundle/CustomerGroupRankBundle.php
@@ -20,11 +20,6 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 
 class CustomerGroupRankBundle extends Bundle
 {
-    /**
-     * @param ContainerBuilder $container
-     *
-     * @return void
-     */
     public function build(ContainerBuilder $container): void
     {
         parent::build($container);

--- a/DependencyInjection/Compiler/RankPass.php
+++ b/DependencyInjection/Compiler/RankPass.php
@@ -24,11 +24,6 @@ class RankPass implements CompilerPassInterface
 
     public const TAG = 'plugin.customer.group.rank';
 
-    /**
-     * @param ContainerBuilder $container
-     *
-     * @return void
-     */
     public function process(ContainerBuilder $container): void
     {
         $context = $container->findDefinition(Context::class);

--- a/Entity/GroupTrait.php
+++ b/Entity/GroupTrait.php
@@ -35,19 +35,11 @@ trait GroupTrait
      */
     private $buyTotal;
 
-    /**
-     * @return float|null
-     */
     public function getBuyTimes(): ?float
     {
         return $this->buyTimes;
     }
 
-    /**
-     * @param float|null $buyTimes
-     *
-     * @return $this
-     */
     public function setBuyTimes(?float $buyTimes): self
     {
         $this->buyTimes = $buyTimes;
@@ -55,19 +47,11 @@ trait GroupTrait
         return $this;
     }
 
-    /**
-     * @return float|null
-     */
     public function getBuyTotal(): ?float
     {
         return $this->buyTotal;
     }
 
-    /**
-     * @param float|null $buyTotal
-     *
-     * @return $this
-     */
     public function setBuyTotal(?float $buyTotal): self
     {
         $this->buyTotal = $buyTotal;

--- a/Event.php
+++ b/Event.php
@@ -18,9 +18,6 @@ use Symfony\Component\EventDispatcher\EventSubscriberInterface;
 
 class Event implements EventSubscriberInterface
 {
-    /**
-     * @return string[]
-     */
     public static function getSubscribedEvents(): array
     {
         return [
@@ -28,11 +25,6 @@ class Event implements EventSubscriberInterface
         ];
     }
 
-    /**
-     * @param TemplateEvent $event
-     *
-     * @return void
-     */
     public function onTemplateAdminCustomerGroupEdit(TemplateEvent $event): void
     {
         $event->addSnippet('@CustomerGroupRank42/admin/Customer/Group/edit.twig');

--- a/Form/Extension/Admin/GroupTypeExtension.php
+++ b/Form/Extension/Admin/GroupTypeExtension.php
@@ -23,12 +23,6 @@ use Symfony\Component\Validator\Constraints\Regex;
 
 class GroupTypeExtension extends AbstractTypeExtension
 {
-    /**
-     * @param FormBuilderInterface $builder
-     * @param array $options
-     *
-     * @return void
-     */
     public function buildForm(FormBuilderInterface $builder, array $options): void
     {
         $builder
@@ -55,9 +49,6 @@ class GroupTypeExtension extends AbstractTypeExtension
             ]);
     }
 
-    /**
-     * @return iterable
-     */
     public static function getExtendedTypes(): iterable
     {
         yield GroupType::class;

--- a/PluginManager.php
+++ b/PluginManager.php
@@ -21,15 +21,6 @@ use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class PluginManager extends AbstractPluginManager
 {
-    /**
-     * @param array $meta
-     * @param ContainerInterface $container
-     *
-     * @return void
-     *
-     * @throws \Psr\Container\ContainerExceptionInterface
-     * @throws \Psr\Container\NotFoundExceptionInterface
-     */
     public function enable(array $meta, ContainerInterface $container): void
     {
         /** @var EntityManagerInterface $entityManager */

--- a/Repository/QueryCustomizer/GroupSearchCustomizer.php
+++ b/Repository/QueryCustomizer/GroupSearchCustomizer.php
@@ -20,18 +20,12 @@ use Plugin\CustomerGroup42\Repository\QueryKey;
 
 class GroupSearchCustomizer implements QueryCustomizer
 {
-    /**
-     * @param QueryBuilder $builder
-     * @param $params
-     * @param $queryKey
-     *
-     * @return void
-     */
     public function customize(QueryBuilder $builder, $params, $queryKey): void
     {
         if (
-            isset($params['buyTimes']) && isset($params['buyTotal'])
-            && StringUtil::isNotBlank($params['buyTimes']) && StringUtil::isNotBlank($params['buyTotal'])
+            isset($params['buyTimes'], $params['buyTotal'])
+            && StringUtil::isNotBlank($params['buyTimes'])
+            && StringUtil::isNotBlank($params['buyTotal'])
         ) {
             $builder
                 ->where('g.buyTimes <= :buyTimes')
@@ -41,9 +35,6 @@ class GroupSearchCustomizer implements QueryCustomizer
         }
     }
 
-    /**
-     * @return string
-     */
     public function getQueryKey(): string
     {
         return QueryKey::GROUP_SEARCH;

--- a/Security/EventListener/LoginListener.php
+++ b/Security/EventListener/LoginListener.php
@@ -20,14 +20,8 @@ use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 
 class LoginListener
 {
-    /**
-     * @var Context
-     */
     private Context $context;
 
-    /**
-     * @var EntityManagerInterface
-     */
     private EntityManagerInterface $entityManager;
 
     public function __construct(Context $context, EntityManagerInterface $entityManager)
@@ -36,11 +30,6 @@ class LoginListener
         $this->entityManager = $entityManager;
     }
 
-    /**
-     * @param InteractiveLoginEvent $event
-     *
-     * @return void
-     */
     public function onInteractiveLogin(InteractiveLoginEvent $event): void
     {
         $user = $event->getAuthenticationToken()->getUser();

--- a/Service/Rank/Context.php
+++ b/Service/Rank/Context.php
@@ -17,26 +17,13 @@ use Eccube\Entity\Customer;
 
 class Context
 {
-    /**
-     * @var array
-     */
     private array $ranks = [];
 
-    /**
-     * @param RankInterface $rank
-     *
-     * @return void
-     */
     public function addRank(RankInterface $rank): void
     {
         $this->ranks[] = $rank;
     }
 
-    /**
-     * @param Customer $customer
-     *
-     * @return void
-     */
     public function decide(Customer $customer): void
     {
         /** @var Rank $rank */

--- a/Service/Rank/Rank.php
+++ b/Service/Rank/Rank.php
@@ -20,9 +20,6 @@ use Plugin\CustomerGroup42\Entity\Group;
 
 class Rank implements RankInterface
 {
-    /**
-     * @var EntityManagerInterface
-     */
     protected EntityManagerInterface $entityManager;
 
     public function __construct(EntityManagerInterface $entityManager)
@@ -32,17 +29,13 @@ class Rank implements RankInterface
 
     /**
      * 優先度が最上位のグループを会員に設定する
-     *
-     * @param Customer $customer
-     *
-     * @return void
      */
     public function decide(Customer $customer): void
     {
         // 会員グループをクリアする
         $customer->getGroups()->clear();
 
-        // 対象の会員ブループが見つかったら登録
+        // 対象の会員グループが見つかったら登録
         $groups = $this->getGroups($customer);
         if ($groups->count() > 0) {
             /** @var Group $group */
@@ -53,10 +46,6 @@ class Rank implements RankInterface
 
     /**
      * 会員に適用可能なグループ一覧を取得
-     *
-     * @param Customer $customer
-     *
-     * @return ArrayCollection
      */
     protected function getGroups(Customer $customer): ArrayCollection
     {

--- a/Service/Rank/RankInterface.php
+++ b/Service/Rank/RankInterface.php
@@ -17,8 +17,5 @@ use Eccube\Entity\Customer;
 
 interface RankInterface
 {
-    /**
-     * @param Customer $customer
-     */
     public function decide(Customer $customer): void;
 }


### PR DESCRIPTION
## Summary
- 型宣言で明らかな `@var`, `@param`, `@return` アノテーションを全ファイルから削除
- `GroupSearchCustomizer` の `isset()` を統合して簡潔に
- `Rank.php` のtypo修正（「会員ブループ」→「会員グループ」）
- Doctrineアノテーションなど必須のコメントは維持
- PHP 7.4互換を維持（EC-CUBE 4.2/4.3両対応）

## Test plan
- [ ] EC-CUBE 4.2環境で動作確認
- [ ] EC-CUBE 4.3環境で動作確認
- [ ] ログイン時のランク判定が正常に動作すること
- [ ] 管理画面のグループ編集が正常に動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)