### PR TITLE
テストのリファクタリングと新規テストの追加

### DIFF
--- a/Tests/DependencyInjection/Compiler/RankPassTest.php
+++ b/Tests/DependencyInjection/Compiler/RankPassTest.php
@@ -22,7 +22,7 @@ use Symfony\Component\DependencyInjection\ContainerBuilder;
 
 class RankPassTest extends TestCase
 {
-    public function testTestRankが追加されるか(): void
+    public function testタグ付きサービスがContextに登録される(): void
     {
         $container = new ContainerBuilder();
         $container->register(Context::class)
@@ -41,6 +41,24 @@ class RankPassTest extends TestCase
         $ranks = $prop->getValue($context);
 
         self::assertCount(1, $ranks);
+    }
+
+    public function testタグ付きサービスが未登録の場合はranksが空(): void
+    {
+        $container = new ContainerBuilder();
+        $container->register(Context::class)
+            ->setPublic(true);
+
+        $container->addCompilerPass(new RankPass());
+        $container->compile();
+
+        $context = $container->get(Context::class);
+        $reflection = new \ReflectionObject($context);
+        $prop = $reflection->getProperty('ranks');
+        $prop->setAccessible(true);
+        $ranks = $prop->getValue($context);
+
+        self::assertCount(0, $ranks);
     }
 }
 

--- a/Tests/Repository/GroupRepositoryTest.php
+++ b/Tests/Repository/GroupRepositoryTest.php
@@ -21,19 +21,6 @@ class GroupRepositoryTest extends EccubeTestCase
 {
     use TestCaseTrait;
 
-    /**
-     * @var array
-     */
-    protected $Results;
-
-    /**
-     * @var array
-     */
-    protected $searchData = [];
-
-    /**
-     * @var GroupRepository
-     */
     protected $groupRepository;
 
     protected function setUp(): void
@@ -44,59 +31,35 @@ class GroupRepositoryTest extends EccubeTestCase
     }
 
     /**
-     * @return void
-     */
-    public function scenario(): void
-    {
-        $this->Results = $this->groupRepository->getQueryBuilderBySearchData($this->searchData)
-            ->getQuery()
-            ->getResult();
-    }
-
-    /**
-     * @param $group_times
-     * @param $group_total
-     * @param $customer_times
-     * @param $customer_total
-     * @param $expected
-     *
-     * @return void
-     *
      * @dataProvider conditionProvider
      */
-    public function testランクアップ条件にマッチした会員グループが見つかるか($group_times, $group_total, $customer_times, $customer_total, $expected): void
+    public function testランクアップ条件にマッチした会員グループが見つかるか($groupTimes, $groupTotal, $customerTimes, $customerTotal, $expected): void
     {
         $group = $this->createGroup();
-        $group->setBuyTimes($group_times);
-        $group->setBuyTotal($group_total);
+        $group->setBuyTimes($groupTimes);
+        $group->setBuyTotal($groupTotal);
 
         $customer = $this->createCustomer();
-        $customer->setBuyTimes($customer_times);
-        $customer->setBuyTotal($customer_total);
+        $customer->setBuyTimes($customerTimes);
+        $customer->setBuyTotal($customerTotal);
 
         $this->entityManager->flush();
 
-        // 絞り込み条件
-        $this->searchData = [
+        $results = $this->groupRepository->getQueryBuilderBySearchData([
             'buyTimes' => $customer->getBuyTimes(),
             'buyTotal' => $customer->getBuyTotal(),
-        ];
+        ])->getQuery()->getResult();
 
-        $this->scenario();
-
-        self::assertCount($expected, $this->Results);
+        self::assertCount($expected, $results);
     }
 
-    /**
-     * @return array[]
-     */
     public function conditionProvider(): array
     {
         return [
-            [1, 1, 0, 0, 0],
-            [10, 1000, 10, 10, 1],
-            [10, 1000, 9, 1000, 1],
-            [10, 1000, 10, 1000, 1],
+            '購入回数・金額ともに未達' => [1, 1, 0, 0, 0],
+            '購入回数のみ達成' => [10, 1000, 10, 10, 1],
+            '購入金額のみ達成' => [10, 1000, 9, 1000, 1],
+            '購入回数・金額ともに達成' => [10, 1000, 10, 1000, 1],
         ];
     }
 }

--- a/Tests/Security/EventListener/LoginListenerTest.php
+++ b/Tests/Security/EventListener/LoginListenerTest.php
@@ -1,0 +1,66 @@
+<?php
+
+/*
+ * This file is part of CustomerGroupRank
+ *
+ * Copyright(c) Akira Kurozumi <info@a-zumi.net>
+ *
+ * https://a-zumi.net
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\CustomerGroupRank42\Tests\Security\EventListener;
+
+use Doctrine\ORM\EntityManagerInterface;
+use Eccube\Entity\Customer;
+use Eccube\Entity\Member;
+use PHPUnit\Framework\TestCase;
+use Plugin\CustomerGroupRank42\Security\EventListener\LoginListener;
+use Plugin\CustomerGroupRank42\Service\Rank\Context;
+use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
+use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
+
+class LoginListenerTest extends TestCase
+{
+    public function testCustomerログイン時にランク判定が実行される(): void
+    {
+        $customer = $this->createMock(Customer::class);
+
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($customer);
+
+        $event = $this->createMock(InteractiveLoginEvent::class);
+        $event->method('getAuthenticationToken')->willReturn($token);
+
+        $context = $this->createMock(Context::class);
+        $context->expects(self::once())->method('decide')->with($customer);
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::once())->method('flush');
+
+        $listener = new LoginListener($context, $entityManager);
+        $listener->onInteractiveLogin($event);
+    }
+
+    public function testCustomer以外のログイン時はランク判定が実行されない(): void
+    {
+        $member = $this->createMock(Member::class);
+
+        $token = $this->createMock(TokenInterface::class);
+        $token->method('getUser')->willReturn($member);
+
+        $event = $this->createMock(InteractiveLoginEvent::class);
+        $event->method('getAuthenticationToken')->willReturn($token);
+
+        $context = $this->createMock(Context::class);
+        $context->expects(self::never())->method('decide');
+
+        $entityManager = $this->createMock(EntityManagerInterface::class);
+        $entityManager->expects(self::never())->method('flush');
+
+        $listener = new LoginListener($context, $entityManager);
+        $listener->onInteractiveLogin($event);
+    }
+}

--- a/Tests/Security/EventListener/LoginListenerTest.php
+++ b/Tests/Security/EventListener/LoginListenerTest.php
@@ -19,6 +19,7 @@ use Eccube\Entity\Member;
 use PHPUnit\Framework\TestCase;
 use Plugin\CustomerGroupRank42\Security\EventListener\LoginListener;
 use Plugin\CustomerGroupRank42\Service\Rank\Context;
+use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
 use Symfony\Component\Security\Http\Event\InteractiveLoginEvent;
 
@@ -31,8 +32,7 @@ class LoginListenerTest extends TestCase
         $token = $this->createMock(TokenInterface::class);
         $token->method('getUser')->willReturn($customer);
 
-        $event = $this->createMock(InteractiveLoginEvent::class);
-        $event->method('getAuthenticationToken')->willReturn($token);
+        $event = new InteractiveLoginEvent(new Request(), $token);
 
         $context = $this->createMock(Context::class);
         $context->expects(self::once())->method('decide')->with($customer);
@@ -51,8 +51,7 @@ class LoginListenerTest extends TestCase
         $token = $this->createMock(TokenInterface::class);
         $token->method('getUser')->willReturn($member);
 
-        $event = $this->createMock(InteractiveLoginEvent::class);
-        $event->method('getAuthenticationToken')->willReturn($token);
+        $event = new InteractiveLoginEvent(new Request(), $token);
 
         $context = $this->createMock(Context::class);
         $context->expects(self::never())->method('decide');

--- a/Tests/Service/Rank/ContextTest.php
+++ b/Tests/Service/Rank/ContextTest.php
@@ -1,0 +1,49 @@
+<?php
+
+/*
+ * This file is part of CustomerGroupRank
+ *
+ * Copyright(c) Akira Kurozumi <info@a-zumi.net>
+ *
+ * https://a-zumi.net
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\CustomerGroupRank42\Tests\Service\Rank;
+
+use Eccube\Entity\Customer;
+use PHPUnit\Framework\TestCase;
+use Plugin\CustomerGroupRank42\Service\Rank\Context;
+use Plugin\CustomerGroupRank42\Service\Rank\RankInterface;
+
+class ContextTest extends TestCase
+{
+    public function test登録された全てのRankが実行される(): void
+    {
+        $context = new Context();
+
+        $rank1 = $this->createMock(RankInterface::class);
+        $rank1->expects(self::once())->method('decide');
+
+        $rank2 = $this->createMock(RankInterface::class);
+        $rank2->expects(self::once())->method('decide');
+
+        $context->addRank($rank1);
+        $context->addRank($rank2);
+
+        $customer = $this->createMock(Customer::class);
+        $context->decide($customer);
+    }
+
+    public function testRank未登録の場合はエラーにならない(): void
+    {
+        $context = new Context();
+        $customer = $this->createMock(Customer::class);
+
+        $context->decide($customer);
+
+        self::assertTrue(true);
+    }
+}

--- a/Tests/Service/Rank/RankTest.php
+++ b/Tests/Service/Rank/RankTest.php
@@ -11,7 +11,7 @@
  * file that was distributed with this source code.
  */
 
-namespace Plugin\CustomerGroupRank42\Tests\Service;
+namespace Plugin\CustomerGroupRank42\Tests\Service\Rank;
 
 use Eccube\Entity\Customer;
 use Eccube\Tests\EccubeTestCase;
@@ -22,9 +22,6 @@ class RankTest extends EccubeTestCase
 {
     use TestCaseTrait;
 
-    /**
-     * @var Context
-     */
     protected $context;
 
     protected function setUp(): void
@@ -34,7 +31,7 @@ class RankTest extends EccubeTestCase
         $this->context = static::getContainer()->get(Context::class);
     }
 
-    public function testDecide(): void
+    public function test優先度が最上位のグループが設定される(): void
     {
         $group1 = $this->createGroup();
         $group1->setBuyTimes(1);
@@ -56,5 +53,52 @@ class RankTest extends EccubeTestCase
         $groups = $this->entityManager->find(Customer::class, $customer->getId())->getGroups();
 
         self::assertEquals($group2, $groups->first());
+    }
+
+    public function test条件にマッチするグループがない場合はグループが空になる(): void
+    {
+        $group = $this->createGroup();
+        $group->setBuyTimes(10);
+        $group->setBuyTotal(10000);
+        $group->setSortNo(1);
+
+        $customer = $this->createCustomer();
+        $customer->setBuyTimes(0);
+        $customer->setBuyTotal(0);
+
+        $this->entityManager->flush();
+
+        $this->context->decide($customer);
+
+        $groups = $this->entityManager->find(Customer::class, $customer->getId())->getGroups();
+
+        self::assertCount(0, $groups);
+    }
+
+    public function test既存のグループがクリアされてから新しいグループが設定される(): void
+    {
+        $group1 = $this->createGroup();
+        $group1->setBuyTimes(1);
+        $group1->setBuyTotal(1000);
+        $group1->setSortNo(1);
+
+        $group2 = $this->createGroup();
+        $group2->setBuyTimes(5);
+        $group2->setBuyTotal(5000);
+        $group2->setSortNo(2);
+
+        $customer = $this->createCustomer();
+        $customer->setBuyTimes(1);
+        $customer->setBuyTotal(1000);
+        $customer->addGroup($group2);
+
+        $this->entityManager->flush();
+
+        $this->context->decide($customer);
+
+        $groups = $this->entityManager->find(Customer::class, $customer->getId())->getGroups();
+
+        self::assertCount(1, $groups);
+        self::assertEquals($group1, $groups->first());
     }
 }


### PR DESCRIPTION
## Summary
- 既存テストから冗長なPHPDocを削除し、テストメソッド名を日本語で明確化
- `RankTest` の名前空間を修正（`Tests\Service` → `Tests\Service\Rank`）
- `GroupRepositoryTest` の `scenario()` メソッドをインライン化、データプロバイダにラベル追加
- `RankPassTest` にタグ未登録時のテストを追加
- `ContextTest` を新規追加（複数Rank実行、Rank未登録時の動作）
- `LoginListenerTest` を新規追加（Customer/Member ログイン時の振る舞い）

## Test plan
- [ ] EC-CUBE 4.2環境でテスト実行
- [ ] EC-CUBE 4.3環境でテスト実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)