### PR TITLE
RankInterface/Contextのdecideメソッドをapplyにリネーム

### DIFF
--- a/Security/EventListener/LoginListener.php
+++ b/Security/EventListener/LoginListener.php
@@ -37,7 +37,7 @@ class LoginListener
             return;
         }
 
-        $this->context->decide($user);
+        $this->context->apply($user);
         $this->entityManager->flush();
     }
 }

--- a/Service/Rank/Context.php
+++ b/Service/Rank/Context.php
@@ -24,11 +24,11 @@ class Context
         $this->ranks[] = $rank;
     }
 
-    public function decide(Customer $customer): void
+    public function apply(Customer $customer): void
     {
         /** @var Rank $rank */
         foreach ($this->ranks as $rank) {
-            $rank->decide($customer);
+            $rank->apply($customer);
         }
     }
 }

--- a/Service/Rank/Rank.php
+++ b/Service/Rank/Rank.php
@@ -30,7 +30,7 @@ class Rank implements RankInterface
     /**
      * 優先度が最上位のグループを会員に設定する
      */
-    public function decide(Customer $customer): void
+    public function apply(Customer $customer): void
     {
         // 会員グループをクリアする
         $customer->getGroups()->clear();

--- a/Service/Rank/RankInterface.php
+++ b/Service/Rank/RankInterface.php
@@ -17,5 +17,5 @@ use Eccube\Entity\Customer;
 
 interface RankInterface
 {
-    public function decide(Customer $customer): void;
+    public function apply(Customer $customer): void;
 }

--- a/Tests/DependencyInjection/Compiler/RankPassTest.php
+++ b/Tests/DependencyInjection/Compiler/RankPassTest.php
@@ -64,7 +64,7 @@ class RankPassTest extends TestCase
 
 class TestRank implements RankInterface
 {
-    public function decide(Customer $customer): void
+    public function apply(Customer $customer): void
     {
     }
 }

--- a/Tests/Security/EventListener/LoginListenerTest.php
+++ b/Tests/Security/EventListener/LoginListenerTest.php
@@ -35,7 +35,7 @@ class LoginListenerTest extends TestCase
         $event = new InteractiveLoginEvent(new Request(), $token);
 
         $context = $this->createMock(Context::class);
-        $context->expects(self::once())->method('decide')->with($customer);
+        $context->expects(self::once())->method('apply')->with($customer);
 
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->expects(self::once())->method('flush');
@@ -54,7 +54,7 @@ class LoginListenerTest extends TestCase
         $event = new InteractiveLoginEvent(new Request(), $token);
 
         $context = $this->createMock(Context::class);
-        $context->expects(self::never())->method('decide');
+        $context->expects(self::never())->method('apply');
 
         $entityManager = $this->createMock(EntityManagerInterface::class);
         $entityManager->expects(self::never())->method('flush');

--- a/Tests/Service/Rank/ContextTest.php
+++ b/Tests/Service/Rank/ContextTest.php
@@ -25,16 +25,16 @@ class ContextTest extends TestCase
         $context = new Context();
 
         $rank1 = $this->createMock(RankInterface::class);
-        $rank1->expects(self::once())->method('decide');
+        $rank1->expects(self::once())->method('apply');
 
         $rank2 = $this->createMock(RankInterface::class);
-        $rank2->expects(self::once())->method('decide');
+        $rank2->expects(self::once())->method('apply');
 
         $context->addRank($rank1);
         $context->addRank($rank2);
 
         $customer = $this->createMock(Customer::class);
-        $context->decide($customer);
+        $context->apply($customer);
     }
 
     public function testRank未登録の場合はエラーにならない(): void
@@ -42,7 +42,7 @@ class ContextTest extends TestCase
         $context = new Context();
         $customer = $this->createMock(Customer::class);
 
-        $context->decide($customer);
+        $context->apply($customer);
 
         self::assertTrue(true);
     }

--- a/Tests/Service/Rank/RankTest.php
+++ b/Tests/Service/Rank/RankTest.php
@@ -48,7 +48,7 @@ class RankTest extends EccubeTestCase
 
         $this->entityManager->flush();
 
-        $this->context->decide($customer);
+        $this->context->apply($customer);
 
         $groups = $this->entityManager->find(Customer::class, $customer->getId())->getGroups();
 
@@ -68,7 +68,7 @@ class RankTest extends EccubeTestCase
 
         $this->entityManager->flush();
 
-        $this->context->decide($customer);
+        $this->context->apply($customer);
 
         $groups = $this->entityManager->find(Customer::class, $customer->getId())->getGroups();
 
@@ -94,7 +94,7 @@ class RankTest extends EccubeTestCase
 
         $this->entityManager->flush();
 
-        $this->context->decide($customer);
+        $this->context->apply($customer);
 
         $groups = $this->entityManager->find(Customer::class, $customer->getId())->getGroups();
 


### PR DESCRIPTION
## Summary
- `RankInterface::decide()` → `RankInterface::apply()` にリネーム
- `Context::decide()` → `Context::apply()` にリネーム
- `Rank::decide()` → `Rank::apply()` にリネーム
- `decide` は人の判断を想起させるため、ランクを判定して会員に適用する処理には `apply` が適切

## Test plan
- [ ] EC-CUBE 4.2環境でテスト実行
- [ ] EC-CUBE 4.3環境でテスト実行

🤖 Generated with [Claude Code](https://claude.com/claude-code)