### PR TITLE
QueryCustomizerのwhere()をandWhere()に修正

### DIFF
--- a/Repository/QueryCustomizer/GroupSearchCustomizer.php
+++ b/Repository/QueryCustomizer/GroupSearchCustomizer.php
@@ -28,8 +28,12 @@ class GroupSearchCustomizer implements QueryCustomizer
             && StringUtil::isNotBlank($params['buyTotal'])
         ) {
             $builder
-                ->where('g.buyTimes <= :buyTimes')
-                ->orWhere('g.buyTotal <= :buyTotal')
+                ->andWhere(
+                    $builder->expr()->orX(
+                        'g.buyTimes <= :buyTimes',
+                        'g.buyTotal <= :buyTotal'
+                    )
+                )
                 ->setParameter('buyTimes', $params['buyTimes'])
                 ->setParameter('buyTotal', $params['buyTotal']);
         }

--- a/Tests/Repository/QueryCustomizer/GroupSearchCustomizerTest.php
+++ b/Tests/Repository/QueryCustomizer/GroupSearchCustomizerTest.php
@@ -43,6 +43,35 @@ class GroupSearchCustomizerTest extends EccubeTestCase
         self::assertStringContainsString('g.buyTotal <= :buyTotal', $dql);
     }
 
+    public function test想定外のパラメータが含まれていても指定条件のみ追加されること(): void
+    {
+        $customizer = new GroupSearchCustomizer();
+
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('g')
+            ->from(Group::class, 'g')
+            ->where('g.id = :id')
+            ->setParameter('id', 1);
+
+        $customizer->customize($qb, [
+            'buyTimes' => 10,
+            'buyTotal' => 1000,
+            'name' => 'test',
+            'unknown' => 'value',
+        ], '');
+
+        $dql = $qb->getDQL();
+
+        // 既存の条件が保持されていること
+        self::assertStringContainsString('g.id = :id', $dql);
+        // 指定条件のみ追加されていること
+        self::assertStringContainsString('g.buyTimes <= :buyTimes', $dql);
+        self::assertStringContainsString('g.buyTotal <= :buyTotal', $dql);
+        // 想定外のパラメータが条件に含まれないこと
+        self::assertStringNotContainsString('name', $dql);
+        self::assertStringNotContainsString('unknown', $dql);
+    }
+
     public function testパラメータが未指定の場合は条件が追加されないこと(): void
     {
         $customizer = new GroupSearchCustomizer();

--- a/Tests/Repository/QueryCustomizer/GroupSearchCustomizerTest.php
+++ b/Tests/Repository/QueryCustomizer/GroupSearchCustomizerTest.php
@@ -1,0 +1,64 @@
+<?php
+
+/*
+ * This file is part of CustomerGroupRank
+ *
+ * Copyright(c) Akira Kurozumi <info@a-zumi.net>
+ *
+ * https://a-zumi.net
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\CustomerGroupRank42\Tests\Repository\QueryCustomizer;
+
+use Eccube\Tests\EccubeTestCase;
+use Plugin\CustomerGroup42\Entity\Group;
+use Plugin\CustomerGroup42\Tests\TestCaseTrait;
+use Plugin\CustomerGroupRank42\Repository\QueryCustomizer\GroupSearchCustomizer;
+
+class GroupSearchCustomizerTest extends EccubeTestCase
+{
+    use TestCaseTrait;
+
+    public function test既存のWHERE条件が上書きされないこと(): void
+    {
+        $customizer = new GroupSearchCustomizer();
+
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('g')
+            ->from(Group::class, 'g')
+            ->where('g.id = :id')
+            ->setParameter('id', 1);
+
+        $customizer->customize($qb, ['buyTimes' => 10, 'buyTotal' => 1000], '');
+
+        $dql = $qb->getDQL();
+
+        // 既存の条件が保持されていること
+        self::assertStringContainsString('g.id = :id', $dql);
+        // 新しい条件も追加されていること
+        self::assertStringContainsString('g.buyTimes <= :buyTimes', $dql);
+        self::assertStringContainsString('g.buyTotal <= :buyTotal', $dql);
+    }
+
+    public function testパラメータが未指定の場合は条件が追加されないこと(): void
+    {
+        $customizer = new GroupSearchCustomizer();
+
+        $qb = $this->entityManager->createQueryBuilder()
+            ->select('g')
+            ->from(Group::class, 'g')
+            ->where('g.id = :id')
+            ->setParameter('id', 1);
+
+        $customizer->customize($qb, [], '');
+
+        $dql = $qb->getDQL();
+
+        self::assertStringContainsString('g.id = :id', $dql);
+        self::assertStringNotContainsString('buyTimes', $dql);
+        self::assertStringNotContainsString('buyTotal', $dql);
+    }
+}


### PR DESCRIPTION
## Summary
- `GroupSearchCustomizer` の `where()` を `andWhere()` + `orX()` に変更
- `where()` は既存のWHERE条件を上書きするため、他のQueryCustomizerが追加した条件が消失する問題を修正
- セキュリティチェックで検出

## Test plan
- [ ] EC-CUBE 4.2環境でテスト実行
- [ ] EC-CUBE 4.3環境でテスト実行
- [ ] ランク判定の検索結果が正しいことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)