### PR TITLE
会員グループごとに送料無料条件を設定できる機能を追加

### DIFF
--- a/Entity/GroupTrait.php
+++ b/Entity/GroupTrait.php
@@ -35,6 +35,20 @@ trait GroupTrait
      */
     private $buyTotal;
 
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(type="decimal", precision=12, scale=2, nullable=true, options={"unsigned":true})
+     */
+    private $deliveryFreeAmount;
+
+    /**
+     * @var string|null
+     *
+     * @ORM\Column(type="decimal", precision=10, scale=0, nullable=true, options={"unsigned":true})
+     */
+    private $deliveryFreeQuantity;
+
     public function getBuyTimes(): ?float
     {
         return $this->buyTimes;
@@ -55,6 +69,30 @@ trait GroupTrait
     public function setBuyTotal(?float $buyTotal): self
     {
         $this->buyTotal = $buyTotal;
+
+        return $this;
+    }
+
+    public function getDeliveryFreeAmount(): ?float
+    {
+        return $this->deliveryFreeAmount;
+    }
+
+    public function setDeliveryFreeAmount(?float $deliveryFreeAmount): self
+    {
+        $this->deliveryFreeAmount = $deliveryFreeAmount;
+
+        return $this;
+    }
+
+    public function getDeliveryFreeQuantity(): ?float
+    {
+        return $this->deliveryFreeQuantity;
+    }
+
+    public function setDeliveryFreeQuantity(?float $deliveryFreeQuantity): self
+    {
+        $this->deliveryFreeQuantity = $deliveryFreeQuantity;
 
         return $this;
     }

--- a/Form/Extension/Admin/GroupTypeExtension.php
+++ b/Form/Extension/Admin/GroupTypeExtension.php
@@ -46,6 +46,28 @@ class GroupTypeExtension extends AbstractTypeExtension
                         'min' => 1,
                     ]),
                 ],
+            ])
+            ->add('deliveryFreeAmount', PriceType::class, [
+                'label' => '送料無料条件（税込み金額）',
+                'required' => false,
+                'constraints' => [
+                    new Range([
+                        'min' => 1,
+                    ]),
+                ],
+            ])
+            ->add('deliveryFreeQuantity', NumberType::class, [
+                'label' => '送料無料条件（数量）',
+                'required' => false,
+                'constraints' => [
+                    new Regex([
+                        'pattern' => "/^\d+$/u",
+                        'message' => 'form_error.numeric_only',
+                    ]),
+                    new Range([
+                        'min' => 1,
+                    ]),
+                ],
             ]);
     }
 

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -12,3 +12,7 @@ services:
     arguments:
       - '@doctrine.orm.default_entity_manager'
 
+  Plugin\CustomerGroupRank42\Service\PurchaseFlow\Processor\GroupDeliveryFreePreprocessor:
+    tags:
+      - { name: eccube.item.holder.preprocessor, flow_type: shopping, priority: 650 }
+

--- a/Resource/template/admin/Customer/Group/edit.twig
+++ b/Resource/template/admin/Customer/Group/edit.twig
@@ -2,6 +2,8 @@
     $(function () {
         $('.card-body').append($('#customer_group_rank_buy_times'));
         $('.card-body').append($('#customer_group_rank_buy_total'));
+        $('.card-body').append($('#customer_group_rank_delivery_free_amount'));
+        $('.card-body').append($('#customer_group_rank_delivery_free_quantity'));
     });
 </script>
 <div class="row mb-2" id="customer_group_rank_buy_times">
@@ -32,6 +34,38 @@
                 </div>
             </div>
             {{ form_errors(form.buyTotal) }}
+        </div>
+    </div>
+</div>
+
+<div class="row mb-2" id="customer_group_rank_delivery_free_amount">
+    <div class="col-3">
+        <span>{{ '送料無料条件（税込み金額）'|trans }}</span>
+    </div>
+    <div class="col">
+        <div class="row">
+            <div class="col">
+                <div>
+                    {{ form_widget(form.deliveryFreeAmount) }}
+                </div>
+            </div>
+            {{ form_errors(form.deliveryFreeAmount) }}
+        </div>
+    </div>
+</div>
+
+<div class="row mb-2" id="customer_group_rank_delivery_free_quantity">
+    <div class="col-3">
+        <span>{{ '送料無料条件（数量）'|trans }}</span>
+    </div>
+    <div class="col">
+        <div class="row">
+            <div class="col">
+                <div>
+                    {{ form_widget(form.deliveryFreeQuantity) }}
+                </div>
+            </div>
+            {{ form_errors(form.deliveryFreeQuantity) }}
         </div>
     </div>
 </div>

--- a/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessor.php
+++ b/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessor.php
@@ -1,0 +1,79 @@
+<?php
+
+/*
+ * This file is part of CustomerGroupRank
+ *
+ * Copyright(c) Akira Kurozumi <info@a-zumi.net>
+ *
+ * https://a-zumi.net
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\CustomerGroupRank42\Service\PurchaseFlow\Processor;
+
+use Eccube\Entity\ItemHolderInterface;
+use Eccube\Entity\Order;
+use Eccube\Service\PurchaseFlow\ItemHolderPreprocessor;
+use Eccube\Service\PurchaseFlow\Processor\DeliveryFeePreprocessor;
+use Eccube\Service\PurchaseFlow\PurchaseContext;
+use Plugin\CustomerGroup42\Entity\Group;
+
+/**
+ * 会員グループごとの送料無料条件を適用する
+ */
+class GroupDeliveryFreePreprocessor implements ItemHolderPreprocessor
+{
+    public function process(ItemHolderInterface $itemHolder, PurchaseContext $context)
+    {
+        if (!$itemHolder instanceof Order) {
+            return;
+        }
+
+        $Customer = $itemHolder->getCustomer();
+        if (!$Customer || !$Customer->hasGroups()) {
+            return;
+        }
+
+        /** @var Group $group */
+        foreach ($Customer->getGroups() as $group) {
+            $deliveryFreeAmount = $group->getDeliveryFreeAmount();
+            $deliveryFreeQuantity = $group->getDeliveryFreeQuantity();
+
+            if (!$deliveryFreeAmount && !$deliveryFreeQuantity) {
+                continue;
+            }
+
+            foreach ($itemHolder->getShippings() as $Shipping) {
+                $isFree = false;
+                $total = 0;
+                $quantity = 0;
+
+                foreach ($Shipping->getProductOrderItems() as $Item) {
+                    $total += $Item->getPriceIncTax() * $Item->getQuantity();
+                    $quantity += $Item->getQuantity();
+                }
+
+                if ($deliveryFreeAmount && $total >= $deliveryFreeAmount) {
+                    $isFree = true;
+                }
+
+                if ($deliveryFreeQuantity && $quantity >= $deliveryFreeQuantity) {
+                    $isFree = true;
+                }
+
+                if ($isFree) {
+                    foreach ($Shipping->getOrderItems() as $Item) {
+                        if ($Item->getProcessorName() == DeliveryFeePreprocessor::class) {
+                            $Item->setQuantity(0);
+                        }
+                    }
+                }
+            }
+
+            // 最初のグループの条件で判定
+            break;
+        }
+    }
+}

--- a/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessor.php
+++ b/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessor.php
@@ -25,7 +25,7 @@ use Plugin\CustomerGroup42\Entity\Group;
  */
 class GroupDeliveryFreePreprocessor implements ItemHolderPreprocessor
 {
-    public function process(ItemHolderInterface $itemHolder, PurchaseContext $context)
+    public function process(ItemHolderInterface $itemHolder, PurchaseContext $context): void
     {
         if (!$itemHolder instanceof Order) {
             return;

--- a/Tests/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessorTest.php
+++ b/Tests/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessorTest.php
@@ -1,0 +1,187 @@
+<?php
+
+/*
+ * This file is part of CustomerGroupRank
+ *
+ * Copyright(c) Akira Kurozumi <info@a-zumi.net>
+ *
+ * https://a-zumi.net
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\CustomerGroupRank42\Tests\Service\PurchaseFlow\Processor;
+
+use Eccube\Entity\Master\OrderItemType;
+use Eccube\Entity\Order;
+use Eccube\Entity\OrderItem;
+use Eccube\Entity\Shipping;
+use Eccube\Service\PurchaseFlow\Processor\DeliveryFeePreprocessor;
+use Eccube\Service\PurchaseFlow\PurchaseContext;
+use Eccube\Tests\EccubeTestCase;
+use Plugin\CustomerGroup42\Tests\TestCaseTrait;
+use Plugin\CustomerGroupRank42\Service\PurchaseFlow\Processor\GroupDeliveryFreePreprocessor;
+
+class GroupDeliveryFreePreprocessorTest extends EccubeTestCase
+{
+    use TestCaseTrait;
+
+    private GroupDeliveryFreePreprocessor $preprocessor;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->preprocessor = new GroupDeliveryFreePreprocessor();
+    }
+
+    public function test送料無料条件を満たす場合は送料が0になる(): void
+    {
+        $group = $this->createGroup();
+        $group->setDeliveryFreeAmount(1000);
+
+        $customer = $this->createCustomer();
+        $customer->addGroup($group);
+
+        $Order = $this->createOrderWithShipping($customer, 1500);
+
+        $this->entityManager->flush();
+
+        $context = new PurchaseContext($Order, $customer);
+        $this->preprocessor->process($Order, $context);
+
+        foreach ($Order->getShippings() as $Shipping) {
+            foreach ($Shipping->getOrderItems() as $Item) {
+                if ($Item->getProcessorName() == DeliveryFeePreprocessor::class) {
+                    self::assertEquals(0, $Item->getQuantity());
+                }
+            }
+        }
+    }
+
+    public function test送料無料条件を満たさない場合は送料がそのまま(): void
+    {
+        $group = $this->createGroup();
+        $group->setDeliveryFreeAmount(10000);
+
+        $customer = $this->createCustomer();
+        $customer->addGroup($group);
+
+        $Order = $this->createOrderWithShipping($customer, 1500);
+
+        $this->entityManager->flush();
+
+        $context = new PurchaseContext($Order, $customer);
+        $this->preprocessor->process($Order, $context);
+
+        foreach ($Order->getShippings() as $Shipping) {
+            foreach ($Shipping->getOrderItems() as $Item) {
+                if ($Item->getProcessorName() == DeliveryFeePreprocessor::class) {
+                    self::assertEquals(1, $Item->getQuantity());
+                }
+            }
+        }
+    }
+
+    public function test数量条件を満たす場合は送料が0になる(): void
+    {
+        $group = $this->createGroup();
+        $group->setDeliveryFreeQuantity(3);
+
+        $customer = $this->createCustomer();
+        $customer->addGroup($group);
+
+        $Order = $this->createOrderWithShipping($customer, 1000, 5);
+
+        $this->entityManager->flush();
+
+        $context = new PurchaseContext($Order, $customer);
+        $this->preprocessor->process($Order, $context);
+
+        foreach ($Order->getShippings() as $Shipping) {
+            foreach ($Shipping->getOrderItems() as $Item) {
+                if ($Item->getProcessorName() == DeliveryFeePreprocessor::class) {
+                    self::assertEquals(0, $Item->getQuantity());
+                }
+            }
+        }
+    }
+
+    public function testグループに送料無料条件が設定されていない場合は何もしない(): void
+    {
+        $group = $this->createGroup();
+
+        $customer = $this->createCustomer();
+        $customer->addGroup($group);
+
+        $Order = $this->createOrderWithShipping($customer, 1500);
+
+        $this->entityManager->flush();
+
+        $context = new PurchaseContext($Order, $customer);
+        $this->preprocessor->process($Order, $context);
+
+        foreach ($Order->getShippings() as $Shipping) {
+            foreach ($Shipping->getOrderItems() as $Item) {
+                if ($Item->getProcessorName() == DeliveryFeePreprocessor::class) {
+                    self::assertEquals(1, $Item->getQuantity());
+                }
+            }
+        }
+    }
+
+    public function testグループに所属していない場合は何もしない(): void
+    {
+        $customer = $this->createCustomer();
+
+        $Order = $this->createOrderWithShipping($customer, 1500);
+
+        $this->entityManager->flush();
+
+        $context = new PurchaseContext($Order, $customer);
+        $this->preprocessor->process($Order, $context);
+
+        foreach ($Order->getShippings() as $Shipping) {
+            foreach ($Shipping->getOrderItems() as $Item) {
+                if ($Item->getProcessorName() == DeliveryFeePreprocessor::class) {
+                    self::assertEquals(1, $Item->getQuantity());
+                }
+            }
+        }
+    }
+
+    private function createOrderWithShipping($Customer, int $priceIncTax, int $quantity = 1): Order
+    {
+        $Order = new Order();
+        $Order->setCustomer($Customer);
+
+        $Shipping = new Shipping();
+        $Shipping->setOrder($Order);
+        $Order->addShipping($Shipping);
+
+        // 商品明細
+        $ProductItem = new OrderItem();
+        $ProductItem->setShipping($Shipping);
+        $ProductItem->setOrder($Order);
+        $ProductItem->setPriceIncTax($priceIncTax);
+        $ProductItem->setQuantity($quantity);
+        $ProductItem->setOrderItemType($this->entityManager->find(OrderItemType::class, OrderItemType::PRODUCT));
+        $Shipping->addOrderItem($ProductItem);
+        $Order->addOrderItem($ProductItem);
+
+        // 送料明細
+        $DeliveryFeeItem = new OrderItem();
+        $DeliveryFeeItem->setShipping($Shipping);
+        $DeliveryFeeItem->setOrder($Order);
+        $DeliveryFeeItem->setQuantity(1);
+        $DeliveryFeeItem->setProcessorName(DeliveryFeePreprocessor::class);
+        $DeliveryFeeItem->setOrderItemType($this->entityManager->find(OrderItemType::class, OrderItemType::DELIVERY_FEE));
+        $Shipping->addOrderItem($DeliveryFeeItem);
+        $Order->addOrderItem($DeliveryFeeItem);
+
+        $this->entityManager->persist($Order);
+
+        return $Order;
+    }
+}

--- a/Tests/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessorTest.php
+++ b/Tests/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessorTest.php
@@ -13,21 +13,19 @@
 
 namespace Plugin\CustomerGroupRank42\Tests\Service\PurchaseFlow\Processor;
 
-use Eccube\Entity\Master\OrderItemType;
-use Eccube\Entity\Master\TaxDisplayType;
+use Doctrine\Common\Collections\ArrayCollection;
+use Eccube\Entity\Customer;
 use Eccube\Entity\Order;
 use Eccube\Entity\OrderItem;
 use Eccube\Entity\Shipping;
 use Eccube\Service\PurchaseFlow\Processor\DeliveryFeePreprocessor;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
-use Eccube\Tests\EccubeTestCase;
-use Plugin\CustomerGroup42\Tests\TestCaseTrait;
+use PHPUnit\Framework\TestCase;
+use Plugin\CustomerGroup42\Entity\Group;
 use Plugin\CustomerGroupRank42\Service\PurchaseFlow\Processor\GroupDeliveryFreePreprocessor;
 
-class GroupDeliveryFreePreprocessorTest extends EccubeTestCase
+class GroupDeliveryFreePreprocessorTest extends TestCase
 {
-    use TestCaseTrait;
-
     private $preprocessor;
 
     protected function setUp(): void
@@ -39,17 +37,11 @@ class GroupDeliveryFreePreprocessorTest extends EccubeTestCase
 
     public function test送料無料条件を満たす場合は送料が0になる(): void
     {
-        $group = $this->createGroup();
-        $group->setDeliveryFreeAmount(1000);
+        $group = $this->createMockGroup(1000, null);
+        $customer = $this->createMockCustomer([$group]);
+        $Order = $this->createMockOrder($customer, 1500);
 
-        $customer = $this->createCustomer();
-        $customer->addGroup($group);
-
-        $Order = $this->createOrderWithShipping($customer, 1500);
-
-        $this->entityManager->flush();
-
-        $context = new PurchaseContext($Order, $customer);
+        $context = $this->createMock(PurchaseContext::class);
         $this->preprocessor->process($Order, $context);
 
         foreach ($Order->getShippings() as $Shipping) {
@@ -63,17 +55,11 @@ class GroupDeliveryFreePreprocessorTest extends EccubeTestCase
 
     public function test送料無料条件を満たさない場合は送料がそのまま(): void
     {
-        $group = $this->createGroup();
-        $group->setDeliveryFreeAmount(10000);
+        $group = $this->createMockGroup(10000, null);
+        $customer = $this->createMockCustomer([$group]);
+        $Order = $this->createMockOrder($customer, 1500);
 
-        $customer = $this->createCustomer();
-        $customer->addGroup($group);
-
-        $Order = $this->createOrderWithShipping($customer, 1500);
-
-        $this->entityManager->flush();
-
-        $context = new PurchaseContext($Order, $customer);
+        $context = $this->createMock(PurchaseContext::class);
         $this->preprocessor->process($Order, $context);
 
         foreach ($Order->getShippings() as $Shipping) {
@@ -87,17 +73,11 @@ class GroupDeliveryFreePreprocessorTest extends EccubeTestCase
 
     public function test数量条件を満たす場合は送料が0になる(): void
     {
-        $group = $this->createGroup();
-        $group->setDeliveryFreeQuantity(3);
+        $group = $this->createMockGroup(null, 3);
+        $customer = $this->createMockCustomer([$group]);
+        $Order = $this->createMockOrder($customer, 1000, 5);
 
-        $customer = $this->createCustomer();
-        $customer->addGroup($group);
-
-        $Order = $this->createOrderWithShipping($customer, 1000, 5);
-
-        $this->entityManager->flush();
-
-        $context = new PurchaseContext($Order, $customer);
+        $context = $this->createMock(PurchaseContext::class);
         $this->preprocessor->process($Order, $context);
 
         foreach ($Order->getShippings() as $Shipping) {
@@ -111,16 +91,11 @@ class GroupDeliveryFreePreprocessorTest extends EccubeTestCase
 
     public function testグループに送料無料条件が設定されていない場合は何もしない(): void
     {
-        $group = $this->createGroup();
+        $group = $this->createMockGroup(null, null);
+        $customer = $this->createMockCustomer([$group]);
+        $Order = $this->createMockOrder($customer, 1500);
 
-        $customer = $this->createCustomer();
-        $customer->addGroup($group);
-
-        $Order = $this->createOrderWithShipping($customer, 1500);
-
-        $this->entityManager->flush();
-
-        $context = new PurchaseContext($Order, $customer);
+        $context = $this->createMock(PurchaseContext::class);
         $this->preprocessor->process($Order, $context);
 
         foreach ($Order->getShippings() as $Shipping) {
@@ -134,13 +109,10 @@ class GroupDeliveryFreePreprocessorTest extends EccubeTestCase
 
     public function testグループに所属していない場合は何もしない(): void
     {
-        $customer = $this->createCustomer();
+        $customer = $this->createMockCustomer([]);
+        $Order = $this->createMockOrder($customer, 1500);
 
-        $Order = $this->createOrderWithShipping($customer, 1500);
-
-        $this->entityManager->flush();
-
-        $context = new PurchaseContext($Order, $customer);
+        $context = $this->createMock(PurchaseContext::class);
         $this->preprocessor->process($Order, $context);
 
         foreach ($Order->getShippings() as $Shipping) {
@@ -152,37 +124,46 @@ class GroupDeliveryFreePreprocessorTest extends EccubeTestCase
         }
     }
 
-    private function createOrderWithShipping($Customer, int $priceIncTax, int $quantity = 1): Order
+    private function createMockGroup(?float $deliveryFreeAmount, ?float $deliveryFreeQuantity): Group
     {
-        $Order = new Order();
-        $Order->setCustomer($Customer);
+        $group = $this->createMock(Group::class);
+        $group->method('getDeliveryFreeAmount')->willReturn($deliveryFreeAmount);
+        $group->method('getDeliveryFreeQuantity')->willReturn($deliveryFreeQuantity);
 
-        $Shipping = new Shipping();
-        $Shipping->setOrder($Order);
-        $Order->addShipping($Shipping);
+        return $group;
+    }
 
-        // 商品明細
-        $ProductItem = new OrderItem();
-        $ProductItem->setShipping($Shipping);
-        $ProductItem->setOrder($Order);
-        $ProductItem->setPrice($priceIncTax);
-        $ProductItem->setTaxDisplayType($this->entityManager->find(TaxDisplayType::class, TaxDisplayType::INCLUDED));
-        $ProductItem->setQuantity($quantity);
-        $ProductItem->setOrderItemType($this->entityManager->find(OrderItemType::class, OrderItemType::PRODUCT));
-        $Shipping->addOrderItem($ProductItem);
-        $Order->addOrderItem($ProductItem);
+    private function createMockCustomer(array $groups): Customer
+    {
+        $customer = $this->createMock(Customer::class);
+        $customer->method('hasGroups')->willReturn(count($groups) > 0);
+        $customer->method('getGroups')->willReturn(new ArrayCollection($groups));
 
-        // 送料明細
+        return $customer;
+    }
+
+    private function createMockOrder($Customer, int $priceIncTax, int $quantity = 1): Order
+    {
+        // 商品明細（モック）
+        $ProductItem = $this->createMock(OrderItem::class);
+        $ProductItem->method('getPriceIncTax')->willReturn($priceIncTax);
+        $ProductItem->method('getQuantity')->willReturn($quantity);
+        $ProductItem->method('getProcessorName')->willReturn(null);
+
+        // 送料明細（実オブジェクト - setQuantityを呼ぶため）
         $DeliveryFeeItem = new OrderItem();
-        $DeliveryFeeItem->setShipping($Shipping);
-        $DeliveryFeeItem->setOrder($Order);
         $DeliveryFeeItem->setQuantity(1);
         $DeliveryFeeItem->setProcessorName(DeliveryFeePreprocessor::class);
-        $DeliveryFeeItem->setOrderItemType($this->entityManager->find(OrderItemType::class, OrderItemType::DELIVERY_FEE));
-        $Shipping->addOrderItem($DeliveryFeeItem);
-        $Order->addOrderItem($DeliveryFeeItem);
 
-        $this->entityManager->persist($Order);
+        // Shipping（モック）
+        $Shipping = $this->createMock(Shipping::class);
+        $Shipping->method('getProductOrderItems')->willReturn(new ArrayCollection([$ProductItem]));
+        $Shipping->method('getOrderItems')->willReturn(new ArrayCollection([$ProductItem, $DeliveryFeeItem]));
+
+        // Order（モック）
+        $Order = $this->createMock(Order::class);
+        $Order->method('getCustomer')->willReturn($Customer);
+        $Order->method('getShippings')->willReturn(new ArrayCollection([$Shipping]));
 
         return $Order;
     }

--- a/Tests/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessorTest.php
+++ b/Tests/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessorTest.php
@@ -14,6 +14,7 @@
 namespace Plugin\CustomerGroupRank42\Tests\Service\PurchaseFlow\Processor;
 
 use Eccube\Entity\Master\OrderItemType;
+use Eccube\Entity\Master\TaxDisplayType;
 use Eccube\Entity\Order;
 use Eccube\Entity\OrderItem;
 use Eccube\Entity\Shipping;
@@ -27,7 +28,7 @@ class GroupDeliveryFreePreprocessorTest extends EccubeTestCase
 {
     use TestCaseTrait;
 
-    private GroupDeliveryFreePreprocessor $preprocessor;
+    private $preprocessor;
 
     protected function setUp(): void
     {
@@ -164,7 +165,8 @@ class GroupDeliveryFreePreprocessorTest extends EccubeTestCase
         $ProductItem = new OrderItem();
         $ProductItem->setShipping($Shipping);
         $ProductItem->setOrder($Order);
-        $ProductItem->setPriceIncTax($priceIncTax);
+        $ProductItem->setPrice($priceIncTax);
+        $ProductItem->setTaxDisplayType($this->entityManager->find(TaxDisplayType::class, TaxDisplayType::INCLUDED));
         $ProductItem->setQuantity($quantity);
         $ProductItem->setOrderItemType($this->entityManager->find(OrderItemType::class, OrderItemType::PRODUCT));
         $Shipping->addOrderItem($ProductItem);


### PR DESCRIPTION
## Summary
- GroupTraitに`deliveryFreeAmount`/`deliveryFreeQuantity`フィールドを追加
- 管理画面のグループ編集フォームに「送料無料条件（税込み金額）」「送料無料条件（数量）」入力欄を追加
- `GroupDeliveryFreePreprocessor`で会員グループの送料無料条件を適用
- PurchaseFlowの`shopping` flowにpreprocessorを登録（priority: 650、EC-CUBE標準の送料無料処理の後に実行）

## 機能詳細
- 送料無料条件は金額または数量で設定可能（どちらか一方を満たせば送料無料）
- 会員が複数グループに所属している場合、最初のグループ（sortNo順）の条件が適用される
- グループに送料無料条件が設定されていない場合は何もしない

## Test plan
- [ ] EC-CUBE 4.2環境でテスト実行
- [ ] EC-CUBE 4.3環境でテスト実行
- [ ] 管理画面でグループに送料無料条件を設定できること
- [ ] 条件を満たす会員の注文で送料が無料になること
- [ ] 条件を満たさない場合は送料がかかること

🤖 Generated with [Claude Code](https://claude.com/claude-code)