### PR TITLE
PurchaseFlowの設定をservices.phpに移行しEC-CUBE 4.2/4.3両対応

### DIFF
--- a/Resource/config/services.php
+++ b/Resource/config/services.php
@@ -13,6 +13,7 @@
 
 namespace Symfony\Component\DependencyInjection\Loader\Configurator;
 
+use Doctrine\Common\Collections\ArrayCollection;
 use Eccube\Common\Constant;
 use Plugin\CustomerGroupRank42\Service\PurchaseFlow\Processor\GroupDeliveryFreePreprocessor;
 
@@ -24,8 +25,20 @@ return function (ContainerConfigurator $containerConfigurator) {
         $services->set(GroupDeliveryFreePreprocessor::class)
             ->tag('eccube.item.holder.preprocessor', ['flow_type' => 'shopping', 'priority' => 650]);
     } else {
-        // EC-CUBE 4.2: priorityは使用不可
-        $services->set(GroupDeliveryFreePreprocessor::class)
-            ->tag('eccube.item.holder.preprocessor', ['flow_type' => 'shopping']);
+        // EC-CUBE 4.2: ArrayCollectionで順序を指定
+        $services->set(GroupDeliveryFreePreprocessor::class);
+
+        $services
+            ->set('eccube.purchase.flow.shopping.item_holder_preprocessors')
+            ->class(ArrayCollection::class)
+            ->args([[
+                service('eccube.purchase.flow.item.holder.preprocessor.tax.processor.before'), // 税額の計算(商品明細)
+                service('eccube.purchase.flow.item.holder.preprocessor.order.no.processor'), // 注文番号
+                service('eccube.purchase.flow.item.holder.preprocessor.delivery.fee.preprocessor'), // 送料
+                service(GroupDeliveryFreePreprocessor::class), // 会員グループ送料無料条件
+                service('eccube.purchase.flow.item.holder.preprocessor.delivery.fee.free.by.shipping.preprocessor'), // 送料無料
+                service('eccube.purchase.flow.item.holder.preprocessor.pyament.charge.preprocessor'), // 手数料
+                service('eccube.purchase.flow.item.holder.preprocessor.tax.processor.after'), // 税額の計算(送料・手数料)
+            ]]);
     }
 };

--- a/Resource/config/services.php
+++ b/Resource/config/services.php
@@ -1,0 +1,31 @@
+<?php
+
+/*
+ * This file is part of CustomerGroupRank
+ *
+ * Copyright(c) Akira Kurozumi <info@a-zumi.net>
+ *
+ * https://a-zumi.net
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Loader\Configurator;
+
+use Eccube\Common\Constant;
+use Plugin\CustomerGroupRank42\Service\PurchaseFlow\Processor\GroupDeliveryFreePreprocessor;
+
+return function (ContainerConfigurator $containerConfigurator) {
+    $services = $containerConfigurator->services();
+
+    if (version_compare(Constant::VERSION, '4.3', '>=')) {
+        // EC-CUBE 4.3以降: タグベースの設定
+        $services->set(GroupDeliveryFreePreprocessor::class)
+            ->tag('eccube.item.holder.preprocessor', ['flow_type' => 'shopping', 'priority' => 650]);
+    } else {
+        // EC-CUBE 4.2: 従来の設定
+        $services->set(GroupDeliveryFreePreprocessor::class)
+            ->tag('eccube.item.holder.preprocessor', ['flow_type' => 'shopping', 'priority' => 650]);
+    }
+};

--- a/Resource/config/services.php
+++ b/Resource/config/services.php
@@ -22,8 +22,9 @@ return function (ContainerConfigurator $containerConfigurator) {
 
     if (version_compare(Constant::VERSION, '4.3', '>=')) {
         // EC-CUBE 4.3以降: タグベースの設定（priorityサポート）
+        // DeliveryFeePreprocessor(800)の後、DeliveryFeeFreeByShippingPreprocessor(700)の前に実行
         $services->set(GroupDeliveryFreePreprocessor::class)
-            ->tag('eccube.item.holder.preprocessor', ['flow_type' => 'shopping', 'priority' => 650]);
+            ->tag('eccube.item.holder.preprocessor', ['flow_type' => 'shopping', 'priority' => 750]);
     } else {
         // EC-CUBE 4.2: ArrayCollectionで順序を指定
         $services->set(GroupDeliveryFreePreprocessor::class);

--- a/Resource/config/services.php
+++ b/Resource/config/services.php
@@ -20,12 +20,12 @@ return function (ContainerConfigurator $containerConfigurator) {
     $services = $containerConfigurator->services();
 
     if (version_compare(Constant::VERSION, '4.3', '>=')) {
-        // EC-CUBE 4.3以降: タグベースの設定
+        // EC-CUBE 4.3以降: タグベースの設定（priorityサポート）
         $services->set(GroupDeliveryFreePreprocessor::class)
             ->tag('eccube.item.holder.preprocessor', ['flow_type' => 'shopping', 'priority' => 650]);
     } else {
-        // EC-CUBE 4.2: 従来の設定
+        // EC-CUBE 4.2: priorityは使用不可
         $services->set(GroupDeliveryFreePreprocessor::class)
-            ->tag('eccube.item.holder.preprocessor', ['flow_type' => 'shopping', 'priority' => 650]);
+            ->tag('eccube.item.holder.preprocessor', ['flow_type' => 'shopping']);
     }
 };

--- a/Resource/config/services.php
+++ b/Resource/config/services.php
@@ -29,16 +29,16 @@ return function (ContainerConfigurator $containerConfigurator) {
         $services->set(GroupDeliveryFreePreprocessor::class);
 
         $services
-            ->set('eccube.purchase.flow.shopping.item_holder_preprocessors')
+            ->set('eccube.purchase.flow.shopping.holder_preprocessors')
             ->class(ArrayCollection::class)
             ->args([[
-                service('eccube.purchase.flow.item.holder.preprocessor.tax.processor.before'), // 税額の計算(商品明細)
-                service('eccube.purchase.flow.item.holder.preprocessor.order.no.processor'), // 注文番号
-                service('eccube.purchase.flow.item.holder.preprocessor.delivery.fee.preprocessor'), // 送料
+                service('Eccube\Service\PurchaseFlow\Processor\TaxProcessor'), // 税額の計算(商品明細)
+                service('Eccube\Service\PurchaseFlow\Processor\OrderNoProcessor'),
+                service('Eccube\Service\PurchaseFlow\Processor\DeliveryFeePreprocessor'),
                 service(GroupDeliveryFreePreprocessor::class), // 会員グループ送料無料条件
-                service('eccube.purchase.flow.item.holder.preprocessor.delivery.fee.free.by.shipping.preprocessor'), // 送料無料
-                service('eccube.purchase.flow.item.holder.preprocessor.pyament.charge.preprocessor'), // 手数料
-                service('eccube.purchase.flow.item.holder.preprocessor.tax.processor.after'), // 税額の計算(送料・手数料)
+                service('Eccube\Service\PurchaseFlow\Processor\DeliveryFeeFreeByShippingPreprocessor'),
+                service('Eccube\Service\PurchaseFlow\Processor\PaymentChargePreprocessor'),
+                service('Eccube\Service\PurchaseFlow\Processor\TaxProcessor'), // 税額の計算(送料・手数料)
             ]]);
     }
 };

--- a/Resource/config/services.yaml
+++ b/Resource/config/services.yaml
@@ -12,7 +12,3 @@ services:
     arguments:
       - '@doctrine.orm.default_entity_manager'
 
-  Plugin\CustomerGroupRank42\Service\PurchaseFlow\Processor\GroupDeliveryFreePreprocessor:
-    tags:
-      - { name: eccube.item.holder.preprocessor, flow_type: shopping, priority: 650 }
-

--- a/Tests/Resource/Config/ServicesPhpTest.php
+++ b/Tests/Resource/Config/ServicesPhpTest.php
@@ -78,7 +78,7 @@ class ServicesPhpTest extends TestCase
 
         $tagAttributes = $tags['eccube.item.holder.preprocessor'][0];
         self::assertEquals('shopping', $tagAttributes['flow_type']);
-        self::assertEquals(650, $tagAttributes['priority']);
+        self::assertEquals(750, $tagAttributes['priority']);
     }
 
     /**
@@ -86,7 +86,7 @@ class ServicesPhpTest extends TestCase
      *
      * @group ec-cube-4.3
      */
-    public function testEC43のPriorityが650である(): void
+    public function testEC43のPriorityが750である(): void
     {
         if (version_compare(Constant::VERSION, '4.3', '<')) {
             self::markTestSkipped('This test is for EC-CUBE 4.3+');
@@ -103,8 +103,9 @@ class ServicesPhpTest extends TestCase
         $priority = $tags['eccube.item.holder.preprocessor'][0]['priority'];
 
         // DeliveryFeePreprocessor(800)の後、DeliveryFeeFreeByShippingPreprocessor(700)の前
-        self::assertEquals(650, $priority);
-        self::assertGreaterThan(500, $priority, 'Priority should be greater than 500 (after TaxProcessor)');
+        // DeliveryFeePreprocessor(800)の後、DeliveryFeeFreeByShippingPreprocessor(700)の前
+        self::assertEquals(750, $priority);
+        self::assertGreaterThan(700, $priority, 'Priority should be greater than 700 (before DeliveryFeeFreeByShippingPreprocessor)');
         self::assertLessThan(800, $priority, 'Priority should be less than 800 (after DeliveryFeePreprocessor)');
     }
 

--- a/Tests/Resource/Config/ServicesPhpTest.php
+++ b/Tests/Resource/Config/ServicesPhpTest.php
@@ -1,0 +1,260 @@
+<?php
+
+/*
+ * This file is part of CustomerGroupRank
+ *
+ * Copyright(c) Akira Kurozumi <info@a-zumi.net>
+ *
+ * https://a-zumi.net
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\CustomerGroupRank42\Tests\Resource\Config;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Eccube\Common\Constant;
+use Eccube\Service\PurchaseFlow\Processor\DeliveryFeePreprocessor;
+use Eccube\Service\PurchaseFlow\Processor\DeliveryFeeFreeByShippingPreprocessor;
+use Eccube\Service\PurchaseFlow\Processor\OrderNoProcessor;
+use Eccube\Service\PurchaseFlow\Processor\PaymentChargePreprocessor;
+use Eccube\Service\PurchaseFlow\Processor\TaxProcessor;
+use Eccube\Service\PurchaseFlow\PurchaseFlow;
+use PHPUnit\Framework\TestCase;
+use Plugin\CustomerGroupRank42\Service\PurchaseFlow\Processor\GroupDeliveryFreePreprocessor;
+use Symfony\Component\Config\FileLocator;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Loader\PhpFileLoader;
+
+/**
+ * services.php設定ファイルのユニットテスト
+ *
+ * EC-CUBE 4.2と4.3で異なる設定方法をテストします。
+ * - EC-CUBE 4.3+: タグベースの設定（priorityサポート）
+ * - EC-CUBE 4.2: ArrayCollectionベースの設定
+ */
+class ServicesPhpTest extends TestCase
+{
+    private $servicesPhpPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->servicesPhpPath = __DIR__.'/../../../Resource/config/services.php';
+    }
+
+    public function testServicesPhpが有効なPHPファイルである(): void
+    {
+        self::assertFileExists($this->servicesPhpPath);
+
+        $callable = require $this->servicesPhpPath;
+
+        self::assertIsCallable($callable);
+    }
+
+    /**
+     * EC-CUBE 4.3+用テスト: タグベースの設定
+     *
+     * @group ec-cube-4.3
+     */
+    public function testEC43ではタグベースの設定が使用される(): void
+    {
+        if (version_compare(Constant::VERSION, '4.3', '<')) {
+            self::markTestSkipped('This test is for EC-CUBE 4.3+');
+        }
+
+        $container = new ContainerBuilder();
+
+        $container->register('eccube.purchase.flow.shopping', PurchaseFlow::class);
+
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../../Resource/config'));
+        $loader->load('services.php');
+
+        $definition = $container->getDefinition(GroupDeliveryFreePreprocessor::class);
+
+        $tags = $definition->getTags();
+        self::assertArrayHasKey('eccube.item.holder.preprocessor', $tags);
+
+        $tagAttributes = $tags['eccube.item.holder.preprocessor'][0];
+        self::assertEquals('shopping', $tagAttributes['flow_type']);
+        self::assertEquals(650, $tagAttributes['priority']);
+    }
+
+    /**
+     * EC-CUBE 4.3+用テスト: priorityが正しく設定されている
+     *
+     * @group ec-cube-4.3
+     */
+    public function testEC43のPriorityが650である(): void
+    {
+        if (version_compare(Constant::VERSION, '4.3', '<')) {
+            self::markTestSkipped('This test is for EC-CUBE 4.3+');
+        }
+
+        $container = new ContainerBuilder();
+        $container->register('eccube.purchase.flow.shopping', PurchaseFlow::class);
+
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../../Resource/config'));
+        $loader->load('services.php');
+
+        $definition = $container->getDefinition(GroupDeliveryFreePreprocessor::class);
+        $tags = $definition->getTags();
+        $priority = $tags['eccube.item.holder.preprocessor'][0]['priority'];
+
+        // DeliveryFeePreprocessor(800)の後、DeliveryFeeFreeByShippingPreprocessor(700)の前
+        self::assertEquals(650, $priority);
+        self::assertGreaterThan(500, $priority, 'Priority should be greater than 500 (after TaxProcessor)');
+        self::assertLessThan(800, $priority, 'Priority should be less than 800 (after DeliveryFeePreprocessor)');
+    }
+
+    /**
+     * EC-CUBE 4.2用テスト: ArrayCollectionベースの設定
+     *
+     * @group ec-cube-4.2
+     */
+    public function testEC42ではArrayCollectionベースの設定が使用される(): void
+    {
+        if (version_compare(Constant::VERSION, '4.3', '>=')) {
+            self::markTestSkipped('This test is for EC-CUBE 4.2');
+        }
+
+        $container = $this->createContainerForEC42();
+
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../../Resource/config'));
+        $loader->load('services.php');
+
+        self::assertTrue($container->hasDefinition('eccube.purchase.flow.shopping.holder_preprocessors'));
+
+        $definition = $container->getDefinition('eccube.purchase.flow.shopping.holder_preprocessors');
+        self::assertEquals(ArrayCollection::class, $definition->getClass());
+    }
+
+    /**
+     * EC-CUBE 4.2用テスト: Preprocessorの順序が正しい
+     *
+     * @group ec-cube-4.2
+     */
+    public function testEC42のPreprocessor順序が正しい(): void
+    {
+        if (version_compare(Constant::VERSION, '4.3', '>=')) {
+            self::markTestSkipped('This test is for EC-CUBE 4.2');
+        }
+
+        $container = $this->createContainerForEC42();
+
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../../Resource/config'));
+        $loader->load('services.php');
+
+        $definition = $container->getDefinition('eccube.purchase.flow.shopping.holder_preprocessors');
+        $arguments = $definition->getArguments();
+        $serviceReferences = $arguments[0];
+
+        $expectedServices = [
+            TaxProcessor::class,
+            OrderNoProcessor::class,
+            DeliveryFeePreprocessor::class,
+            GroupDeliveryFreePreprocessor::class,
+            DeliveryFeeFreeByShippingPreprocessor::class,
+            PaymentChargePreprocessor::class,
+            TaxProcessor::class,
+        ];
+
+        self::assertCount(count($expectedServices), $serviceReferences);
+
+        foreach ($serviceReferences as $index => $reference) {
+            $serviceId = (string) $reference;
+            self::assertEquals($expectedServices[$index], $serviceId, "Index {$index} should be {$expectedServices[$index]}");
+        }
+    }
+
+    /**
+     * EC-CUBE 4.2用テスト: GroupDeliveryFreePreprocessorがDeliveryFeePreprocessorの後にある
+     *
+     * @group ec-cube-4.2
+     */
+    public function testEC42でGroupDeliveryFreePreprocessorがDeliveryFeePreprocessorの後(): void
+    {
+        if (version_compare(Constant::VERSION, '4.3', '>=')) {
+            self::markTestSkipped('This test is for EC-CUBE 4.2');
+        }
+
+        $container = $this->createContainerForEC42();
+
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../../Resource/config'));
+        $loader->load('services.php');
+
+        $definition = $container->getDefinition('eccube.purchase.flow.shopping.holder_preprocessors');
+        $serviceReferences = $definition->getArguments()[0];
+
+        $deliveryFeeIndex = null;
+        $groupDeliveryFreeIndex = null;
+
+        foreach ($serviceReferences as $index => $reference) {
+            $serviceId = (string) $reference;
+            if ($serviceId === DeliveryFeePreprocessor::class) {
+                $deliveryFeeIndex = $index;
+            }
+            if ($serviceId === GroupDeliveryFreePreprocessor::class) {
+                $groupDeliveryFreeIndex = $index;
+            }
+        }
+
+        self::assertNotNull($deliveryFeeIndex, 'DeliveryFeePreprocessor should exist');
+        self::assertNotNull($groupDeliveryFreeIndex, 'GroupDeliveryFreePreprocessor should exist');
+        self::assertGreaterThan($deliveryFeeIndex, $groupDeliveryFreeIndex, 'GroupDeliveryFreePreprocessor should be after DeliveryFeePreprocessor');
+    }
+
+    /**
+     * EC-CUBE 4.2用テスト: GroupDeliveryFreePreprocessorがDeliveryFeeFreeByShippingPreprocessorの前にある
+     *
+     * @group ec-cube-4.2
+     */
+    public function testEC42でGroupDeliveryFreePreprocessorがDeliveryFeeFreeByShippingPreprocessorの前(): void
+    {
+        if (version_compare(Constant::VERSION, '4.3', '>=')) {
+            self::markTestSkipped('This test is for EC-CUBE 4.2');
+        }
+
+        $container = $this->createContainerForEC42();
+
+        $loader = new PhpFileLoader($container, new FileLocator(__DIR__.'/../../../Resource/config'));
+        $loader->load('services.php');
+
+        $definition = $container->getDefinition('eccube.purchase.flow.shopping.holder_preprocessors');
+        $serviceReferences = $definition->getArguments()[0];
+
+        $groupDeliveryFreeIndex = null;
+        $deliveryFeeFreeByShippingIndex = null;
+
+        foreach ($serviceReferences as $index => $reference) {
+            $serviceId = (string) $reference;
+            if ($serviceId === GroupDeliveryFreePreprocessor::class) {
+                $groupDeliveryFreeIndex = $index;
+            }
+            if ($serviceId === DeliveryFeeFreeByShippingPreprocessor::class) {
+                $deliveryFeeFreeByShippingIndex = $index;
+            }
+        }
+
+        self::assertNotNull($groupDeliveryFreeIndex, 'GroupDeliveryFreePreprocessor should exist');
+        self::assertNotNull($deliveryFeeFreeByShippingIndex, 'DeliveryFeeFreeByShippingPreprocessor should exist');
+        self::assertLessThan($deliveryFeeFreeByShippingIndex, $groupDeliveryFreeIndex, 'GroupDeliveryFreePreprocessor should be before DeliveryFeeFreeByShippingPreprocessor');
+    }
+
+    /**
+     * EC-CUBE 4.2用のコンテナを作成
+     */
+    private function createContainerForEC42(): ContainerBuilder
+    {
+        $container = new ContainerBuilder();
+
+        $container->register(TaxProcessor::class)->setPublic(true);
+        $container->register(OrderNoProcessor::class)->setPublic(true);
+        $container->register(DeliveryFeePreprocessor::class)->setPublic(true);
+        $container->register(DeliveryFeeFreeByShippingPreprocessor::class)->setPublic(true);
+        $container->register(PaymentChargePreprocessor::class)->setPublic(true);
+
+        return $container;
+    }
+}

--- a/Tests/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessorWebTest.php
+++ b/Tests/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessorWebTest.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of CustomerGroupRank
+ *
+ * Copyright(c) Akira Kurozumi <info@a-zumi.net>
+ *
+ * https://a-zumi.net
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\CustomerGroupRank42\Tests\Service\PurchaseFlow\Processor;
+
+use Doctrine\Common\Collections\ArrayCollection;
+use Eccube\Service\PurchaseFlow\Processor\DeliveryFeePreprocessor;
+use Eccube\Service\PurchaseFlow\Processor\DeliveryFeeFreeByShippingPreprocessor;
+use Eccube\Service\PurchaseFlow\PurchaseFlow;
+use Eccube\Tests\EccubeTestCase;
+use Plugin\CustomerGroupRank42\Service\PurchaseFlow\Processor\GroupDeliveryFreePreprocessor;
+
+/**
+ * GroupDeliveryFreePreprocessorの統合テスト
+ *
+ * 実際のEC-CUBEコンテナでPurchaseFlowの設定を検証します。
+ * EC-CUBE 4.2と4.3の両方で動作します。
+ *
+ * Note: このテストはプラグインがインストールされている環境で実行する必要があります。
+ */
+class GroupDeliveryFreePreprocessorWebTest extends EccubeTestCase
+{
+    /**
+     * @var PurchaseFlow
+     */
+    private $shoppingFlow;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // プラグインがインストールされているか確認
+        if (!static::getContainer()->has(GroupDeliveryFreePreprocessor::class)) {
+            self::markTestSkipped('CustomerGroupRank42 plugin is not installed');
+        }
+
+        $this->shoppingFlow = static::getContainer()->get('eccube.purchase.flow.shopping');
+    }
+
+    public function testGroupDeliveryFreePreprocessorがコンテナに登録されている(): void
+    {
+        self::assertTrue(
+            static::getContainer()->has(GroupDeliveryFreePreprocessor::class),
+            'GroupDeliveryFreePreprocessor should be registered in container'
+        );
+    }
+
+    public function testGroupDeliveryFreePreprocessorがショッピングフローに登録されている(): void
+    {
+        $preprocessors = $this->getItemHolderPreprocessors();
+
+        $found = false;
+        foreach ($preprocessors as $preprocessor) {
+            if ($preprocessor instanceof GroupDeliveryFreePreprocessor) {
+                $found = true;
+                break;
+            }
+        }
+
+        self::assertTrue($found, 'GroupDeliveryFreePreprocessor should be registered in shopping flow');
+    }
+
+    public function testGroupDeliveryFreePreprocessorがDeliveryFeePreprocessorの後に実行される(): void
+    {
+        $preprocessors = $this->getItemHolderPreprocessors();
+
+        $deliveryFeeIndex = null;
+        $groupDeliveryFreeIndex = null;
+
+        foreach ($preprocessors as $index => $preprocessor) {
+            if ($preprocessor instanceof DeliveryFeePreprocessor) {
+                $deliveryFeeIndex = $index;
+            }
+            if ($preprocessor instanceof GroupDeliveryFreePreprocessor) {
+                $groupDeliveryFreeIndex = $index;
+            }
+        }
+
+        self::assertNotNull($deliveryFeeIndex, 'DeliveryFeePreprocessor should be registered');
+        self::assertNotNull($groupDeliveryFreeIndex, 'GroupDeliveryFreePreprocessor should be registered');
+        self::assertGreaterThan(
+            $deliveryFeeIndex,
+            $groupDeliveryFreeIndex,
+            'GroupDeliveryFreePreprocessor should run after DeliveryFeePreprocessor'
+        );
+    }
+
+    public function testGroupDeliveryFreePreprocessorがDeliveryFeeFreeByShippingPreprocessorの前に実行される(): void
+    {
+        $preprocessors = $this->getItemHolderPreprocessors();
+
+        $groupDeliveryFreeIndex = null;
+        $deliveryFeeFreeByShippingIndex = null;
+
+        foreach ($preprocessors as $index => $preprocessor) {
+            if ($preprocessor instanceof GroupDeliveryFreePreprocessor) {
+                $groupDeliveryFreeIndex = $index;
+            }
+            if ($preprocessor instanceof DeliveryFeeFreeByShippingPreprocessor) {
+                $deliveryFeeFreeByShippingIndex = $index;
+            }
+        }
+
+        self::assertNotNull($groupDeliveryFreeIndex, 'GroupDeliveryFreePreprocessor should be registered');
+        self::assertNotNull($deliveryFeeFreeByShippingIndex, 'DeliveryFeeFreeByShippingPreprocessor should be registered');
+        self::assertLessThan(
+            $deliveryFeeFreeByShippingIndex,
+            $groupDeliveryFreeIndex,
+            'GroupDeliveryFreePreprocessor should run before DeliveryFeeFreeByShippingPreprocessor'
+        );
+    }
+
+    public function testPreprocessorの順序が正しい(): void
+    {
+        $preprocessors = $this->getItemHolderPreprocessors();
+
+        $classes = [];
+        foreach ($preprocessors as $preprocessor) {
+            $classes[] = get_class($preprocessor);
+        }
+
+        // GroupDeliveryFreePreprocessorの位置を確認
+        $deliveryFeePos = array_search(DeliveryFeePreprocessor::class, $classes, true);
+        $groupDeliveryFreePos = array_search(GroupDeliveryFreePreprocessor::class, $classes, true);
+        $deliveryFeeFreePos = array_search(DeliveryFeeFreeByShippingPreprocessor::class, $classes, true);
+
+        self::assertNotFalse($deliveryFeePos, 'DeliveryFeePreprocessor should exist');
+        self::assertNotFalse($groupDeliveryFreePos, 'GroupDeliveryFreePreprocessor should exist');
+        self::assertNotFalse($deliveryFeeFreePos, 'DeliveryFeeFreeByShippingPreprocessor should exist');
+
+        // 順序: DeliveryFee < GroupDeliveryFree < DeliveryFeeFree
+        self::assertLessThan($groupDeliveryFreePos, $deliveryFeePos, 'DeliveryFeePreprocessor should be before GroupDeliveryFreePreprocessor');
+        self::assertLessThan($deliveryFeeFreePos, $groupDeliveryFreePos, 'GroupDeliveryFreePreprocessor should be before DeliveryFeeFreeByShippingPreprocessor');
+    }
+
+    private function getItemHolderPreprocessors(): ArrayCollection
+    {
+        $reflection = new \ReflectionObject($this->shoppingFlow);
+        $property = $reflection->getProperty('itemHolderPreprocessors');
+        $property->setAccessible(true);
+
+        return $property->getValue($this->shoppingFlow);
+    }
+}


### PR DESCRIPTION
## Summary
- `GroupDeliveryFreePreprocessor`の設定を`services.yaml`から`services.php`に移行
- `Constant::VERSION`でバージョン分岐を行い、4.2/4.3両対応
- EC-CUBE 4.2と4.3でPurchaseFlowの仕組みが異なるため対応

## 参考
https://doc4.ec-cube.net/update-42-43

## Test plan
- [ ] EC-CUBE 4.2環境でテスト実行
- [ ] EC-CUBE 4.3環境でテスト実行
- [ ] 送料無料条件が正しく動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)