### PR TITLE
送料無料条件をsortNo昇順で最上位のグループで判定

### DIFF
--- a/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessor.php
+++ b/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessor.php
@@ -36,44 +36,51 @@ class GroupDeliveryFreePreprocessor implements ItemHolderPreprocessor
             return;
         }
 
-        /** @var Group $group */
-        foreach ($Customer->getGroups() as $group) {
-            $deliveryFreeAmount = $group->getDeliveryFreeAmount();
-            $deliveryFreeQuantity = $group->getDeliveryFreeQuantity();
+        // sortNo昇順でソートして最上位のグループを取得
+        $groups = $Customer->getGroups()->toArray();
+        usort($groups, function (Group $a, Group $b) {
+            return $a->getSortNo() <=> $b->getSortNo();
+        });
 
-            if (!$deliveryFreeAmount && !$deliveryFreeQuantity) {
-                continue;
+        /** @var Group $group */
+        $group = reset($groups);
+        if (!$group) {
+            return;
+        }
+
+        $deliveryFreeAmount = $group->getDeliveryFreeAmount();
+        $deliveryFreeQuantity = $group->getDeliveryFreeQuantity();
+
+        // 送料無料条件が設定されていない場合は何もしない
+        if (!$deliveryFreeAmount && !$deliveryFreeQuantity) {
+            return;
+        }
+
+        foreach ($itemHolder->getShippings() as $Shipping) {
+            $isFree = false;
+            $total = 0;
+            $quantity = 0;
+
+            foreach ($Shipping->getProductOrderItems() as $Item) {
+                $total += $Item->getPriceIncTax() * $Item->getQuantity();
+                $quantity += $Item->getQuantity();
             }
 
-            foreach ($itemHolder->getShippings() as $Shipping) {
-                $isFree = false;
-                $total = 0;
-                $quantity = 0;
+            if ($deliveryFreeAmount && $total >= $deliveryFreeAmount) {
+                $isFree = true;
+            }
 
-                foreach ($Shipping->getProductOrderItems() as $Item) {
-                    $total += $Item->getPriceIncTax() * $Item->getQuantity();
-                    $quantity += $Item->getQuantity();
-                }
+            if ($deliveryFreeQuantity && $quantity >= $deliveryFreeQuantity) {
+                $isFree = true;
+            }
 
-                if ($deliveryFreeAmount && $total >= $deliveryFreeAmount) {
-                    $isFree = true;
-                }
-
-                if ($deliveryFreeQuantity && $quantity >= $deliveryFreeQuantity) {
-                    $isFree = true;
-                }
-
-                if ($isFree) {
-                    foreach ($Shipping->getOrderItems() as $Item) {
-                        if ($Item->getProcessorName() == DeliveryFeePreprocessor::class) {
-                            $Item->setQuantity(0);
-                        }
+            if ($isFree) {
+                foreach ($Shipping->getOrderItems() as $Item) {
+                    if ($Item->getProcessorName() == DeliveryFeePreprocessor::class) {
+                        $Item->setQuantity(0);
                     }
                 }
             }
-
-            // 最初のグループの条件で判定
-            break;
         }
     }
 }

--- a/Tests/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessorTest.php
+++ b/Tests/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessorTest.php
@@ -124,18 +124,75 @@ class GroupDeliveryFreePreprocessorTest extends TestCase
         }
     }
 
+    public function testSortNo昇順で最上位のグループの条件が適用される(): void
+    {
+        // sortNo=2のグループ（送料無料条件なし）
+        $group1 = $this->createMockGroupWithSortNo(null, null, 2);
+        // sortNo=1のグループ（送料無料条件あり）- こちらが優先される
+        $group2 = $this->createMockGroupWithSortNo(1000, null, 1);
+
+        $customer = $this->createMockCustomer([$group1, $group2]);
+        $Order = $this->createMockOrder($customer, 1500);
+
+        $context = $this->createMock(PurchaseContext::class);
+        $this->preprocessor->process($Order, $context);
+
+        foreach ($Order->getShippings() as $Shipping) {
+            foreach ($Shipping->getOrderItems() as $Item) {
+                if ($Item->getProcessorName() == DeliveryFeePreprocessor::class) {
+                    // sortNo=1のグループの条件（1000円以上で送料無料）が適用される
+                    self::assertEquals(0, $Item->getQuantity());
+                }
+            }
+        }
+    }
+
+    public function testSortNo昇順で最上位のグループに条件がない場合は送料がそのまま(): void
+    {
+        // sortNo=1のグループ（送料無料条件なし）- こちらが優先される
+        $group1 = $this->createMockGroupWithSortNo(null, null, 1);
+        // sortNo=2のグループ（送料無料条件あり）
+        $group2 = $this->createMockGroupWithSortNo(1000, null, 2);
+
+        $customer = $this->createMockCustomer([$group1, $group2]);
+        $Order = $this->createMockOrder($customer, 1500);
+
+        $context = $this->createMock(PurchaseContext::class);
+        $this->preprocessor->process($Order, $context);
+
+        foreach ($Order->getShippings() as $Shipping) {
+            foreach ($Shipping->getOrderItems() as $Item) {
+                if ($Item->getProcessorName() == DeliveryFeePreprocessor::class) {
+                    // sortNo=1のグループに条件がないため、送料はそのまま
+                    self::assertEquals(1, $Item->getQuantity());
+                }
+            }
+        }
+    }
+
     private function createMockGroup(?float $deliveryFreeAmount, ?float $deliveryFreeQuantity): Group
     {
-        $group = $this->createMock(Group::class);
+        return $this->createMockGroupWithSortNo($deliveryFreeAmount, $deliveryFreeQuantity, 1);
+    }
+
+    private function createMockGroupWithSortNo(?float $deliveryFreeAmount, ?float $deliveryFreeQuantity, int $sortNo): Group
+    {
+        $group = $this->getMockBuilder(Group::class)
+            ->onlyMethods(['getSortNo'])
+            ->addMethods(['getDeliveryFreeAmount', 'getDeliveryFreeQuantity'])
+            ->getMock();
         $group->method('getDeliveryFreeAmount')->willReturn($deliveryFreeAmount);
         $group->method('getDeliveryFreeQuantity')->willReturn($deliveryFreeQuantity);
+        $group->method('getSortNo')->willReturn($sortNo);
 
         return $group;
     }
 
     private function createMockCustomer(array $groups): Customer
     {
-        $customer = $this->createMock(Customer::class);
+        $customer = $this->getMockBuilder(Customer::class)
+            ->addMethods(['hasGroups', 'getGroups'])
+            ->getMock();
         $customer->method('hasGroups')->willReturn(count($groups) > 0);
         $customer->method('getGroups')->willReturn(new ArrayCollection($groups));
 


### PR DESCRIPTION
## Summary
- グループをsortNo昇順でソート
- 最上位のグループ（sortNo最小）の送料無料条件のみを適用
- 最上位グループに条件が設定されていない場合は何もしない

## Test plan
- [x] sortNo昇順で最上位のグループの条件が適用されることをテスト
- [x] 最上位グループに条件がない場合は送料がそのままになることをテスト

🤖 Generated with [Claude Code](https://claude.com/claude-code)