### PR TITLE
CodeceptionによるE2Eテストをセットアップ

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -6,3 +6,5 @@
 /phpstan.neon               export-ignore
 /phpunit.xml.dist           export-ignore
 /Tests                      export-ignore
+/codeception                export-ignore
+/codeception.yml            export-ignore

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -1,0 +1,124 @@
+name: E2E Tests
+
+on:
+  push:
+    branches:
+      - '**'
+    paths-ignore:
+      - '**.md'
+  pull_request:
+    paths-ignore:
+      - '**.md'
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    name: E2E Tests (EC-CUBE ${{ matrix.eccube }}, PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        eccube: ['4.2', '4.3']
+        php: ['8.1']
+        include:
+          - eccube: '4.2'
+            php: '7.4'
+
+    services:
+      mysql:
+        image: mysql:5.7
+        env:
+          MYSQL_ROOT_PASSWORD: root
+          MYSQL_DATABASE: eccube_db
+        ports:
+          - 3306:3306
+        options: --health-cmd="mysqladmin ping" --health-interval=10s --health-timeout=5s --health-retries=3
+
+      chrome:
+        image: selenium/standalone-chrome:latest
+        ports:
+          - 4444:4444
+
+    env:
+      DATABASE_URL: mysql://root:root@127.0.0.1:3306/eccube_db
+      DATABASE_SERVER_VERSION: 5.7
+      APP_ENV: dev
+      APP_DEBUG: 1
+      ECCUBE_ADMIN_ROUTE: admin
+      ADMIN_USER: admin
+      ADMIN_PASSWORD: password
+      SELENIUM_HOST: 127.0.0.1
+      SELENIUM_PORT: 4444
+      BASE_URL: http://127.0.0.1:8000
+
+    steps:
+      - name: Checkout EC-CUBE
+        uses: actions/checkout@v4
+        with:
+          repository: EC-CUBE/ec-cube
+          ref: ${{ matrix.eccube }}
+          path: ec-cube
+
+      - name: Checkout Plugin
+        uses: actions/checkout@v4
+        with:
+          path: ec-cube/app/Plugin/CustomerGroupRank42
+
+      - name: Checkout CustomerGroup42
+        uses: actions/checkout@v4
+        with:
+          repository: kurozumi/eccube-plugin-customer-group
+          ref: '4.2'
+          path: ec-cube/app/Plugin/CustomerGroup42
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, xml, ctype, iconv, mysql, intl
+
+      - name: Get Composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache Composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: ${{ runner.os }}-composer-
+
+      - name: Install EC-CUBE
+        working-directory: ec-cube
+        run: |
+          composer install --no-interaction --prefer-dist
+          bin/console eccube:install --no-interaction
+
+      - name: Enable Plugins
+        working-directory: ec-cube
+        run: |
+          bin/console eccube:plugin:enable --code=CustomerGroup42
+          bin/console eccube:plugin:enable --code=CustomerGroupRank42
+
+      - name: Start PHP built-in server
+        working-directory: ec-cube
+        run: |
+          php -S 127.0.0.1:8000 -t . &
+          sleep 5
+
+      - name: Build Codeception
+        working-directory: ec-cube/app/Plugin/CustomerGroupRank42
+        run: |
+          ../../../vendor/bin/codecept build
+
+      - name: Run E2E Tests
+        working-directory: ec-cube/app/Plugin/CustomerGroupRank42
+        run: |
+          ../../../vendor/bin/codecept run acceptance --env chrome -vvv
+
+      - name: Upload artifacts
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: e2e-screenshots-${{ matrix.eccube }}-${{ matrix.php }}
+          path: ec-cube/app/Plugin/CustomerGroupRank42/codeception/_output/

--- a/codeception.yml
+++ b/codeception.yml
@@ -1,0 +1,14 @@
+paths:
+    tests: codeception
+    output: codeception/_output
+    data: codeception/_data
+    support: codeception/_support
+    envs: codeception/_envs
+actor_suffix: Tester
+settings:
+    bootstrap: _bootstrap.php
+extensions:
+    enabled:
+        - Codeception\Extension\RunFailed
+params:
+    - env

--- a/codeception/.gitignore
+++ b/codeception/.gitignore
@@ -1,0 +1,3 @@
+_output/*
+!_output/.gitkeep
+_support/_generated/

--- a/codeception/_bootstrap.php
+++ b/codeception/_bootstrap.php
@@ -1,0 +1,30 @@
+<?php
+
+/*
+ * This file is part of CustomerGroupRank
+ *
+ * Copyright(c) Akira Kurozumi <info@a-zumi.net>
+ *
+ * https://a-zumi.net
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+// EC-CUBEのautoloaderを読み込む
+$autoloader = require __DIR__.'/../../../../vendor/autoload.php';
+
+// テスト用の設定を読み込む
+\Codeception\Util\Fixtures::add('config', [
+    'eccube_admin_route' => getenv('ECCUBE_ADMIN_ROUTE') ?: 'admin',
+]);
+
+\Codeception\Util\Fixtures::add('admin_account', [
+    'member' => getenv('ADMIN_USER') ?: 'admin',
+    'password' => getenv('ADMIN_PASSWORD') ?: 'password',
+]);
+
+\Codeception\Util\Fixtures::add('customer_account', [
+    'email' => getenv('CUSTOMER_EMAIL') ?: 'test@example.com',
+    'password' => getenv('CUSTOMER_PASSWORD') ?: 'password',
+]);

--- a/codeception/_support/AcceptanceTester.php
+++ b/codeception/_support/AcceptanceTester.php
@@ -1,0 +1,92 @@
+<?php
+
+/*
+ * This file is part of CustomerGroupRank
+ *
+ * Copyright(c) Akira Kurozumi <info@a-zumi.net>
+ *
+ * https://a-zumi.net
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+use Codeception\Actor;
+use Codeception\Util\Fixtures;
+
+/**
+ * @method void wantToTest($text)
+ * @method void wantTo($text)
+ * @method void execute($callable)
+ * @method void expectTo($prediction)
+ * @method void expect($prediction)
+ * @method void amGoingTo($argumentation)
+ * @method void am($role)
+ * @method void lookForwardTo($achieveValue)
+ * @method void comment($description)
+ */
+class AcceptanceTester extends Actor
+{
+    use _generated\AcceptanceTesterActions;
+
+    /**
+     * 管理者としてログイン
+     */
+    public function loginAsAdmin(string $user = '', string $password = ''): void
+    {
+        if (!$user || !$password) {
+            $account = Fixtures::get('admin_account');
+            $user = $account['member'];
+            $password = $account['password'];
+        }
+
+        $config = Fixtures::get('config');
+        $this->amOnPage('/'.$config['eccube_admin_route'].'/');
+
+        $this->submitForm('#form1', [
+            'login_id' => $user,
+            'password' => $password,
+        ]);
+
+        $this->see('ホーム', '.c-pageTitle__title');
+    }
+
+    /**
+     * 会員としてログイン
+     */
+    public function loginAsMember(string $email = '', string $password = ''): void
+    {
+        if (!$email || !$password) {
+            $account = Fixtures::get('customer_account');
+            $email = $account['email'];
+            $password = $account['password'];
+        }
+
+        $this->amOnPage('/mypage/login');
+
+        $this->submitForm('#login_mypage', [
+            'login_email' => $email,
+            'login_pass' => $password,
+        ]);
+
+        $this->see('マイページ');
+    }
+
+    /**
+     * 会員グループ管理ページに移動
+     */
+    public function goToGroupManagePage(): void
+    {
+        $config = Fixtures::get('config');
+        $this->amOnPage('/'.$config['eccube_admin_route'].'/customer/group');
+    }
+
+    /**
+     * 会員グループ編集ページに移動
+     */
+    public function goToGroupEditPage(int $groupId): void
+    {
+        $config = Fixtures::get('config');
+        $this->amOnPage('/'.$config['eccube_admin_route'].'/customer/group/'.$groupId.'/edit');
+    }
+}

--- a/codeception/_support/Helper/Acceptance.php
+++ b/codeception/_support/Helper/Acceptance.php
@@ -1,0 +1,20 @@
+<?php
+
+/*
+ * This file is part of CustomerGroupRank
+ *
+ * Copyright(c) Akira Kurozumi <info@a-zumi.net>
+ *
+ * https://a-zumi.net
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Helper;
+
+use Codeception\Module;
+
+class Acceptance extends Module
+{
+}

--- a/codeception/acceptance.suite.yml
+++ b/codeception/acceptance.suite.yml
@@ -1,0 +1,31 @@
+actor: AcceptanceTester
+modules:
+    enabled:
+        - WebDriver:
+            host: '%SELENIUM_HOST%'
+            port: '%SELENIUM_PORT%'
+            url: '%BASE_URL%'
+            browser: chrome
+            window_size: 1920x1080
+            wait: 10
+            capabilities:
+                goog:chromeOptions:
+                    args: ["--headless", "--disable-gpu", "--no-sandbox", "--disable-dev-shm-usage"]
+        - Asserts
+        - \Helper\Acceptance
+
+env:
+    chrome:
+        modules:
+            config:
+                WebDriver:
+                    browser: chrome
+                    capabilities:
+                        goog:chromeOptions:
+                            args: ["--headless", "--disable-gpu", "--no-sandbox"]
+
+    firefox:
+        modules:
+            config:
+                WebDriver:
+                    browser: firefox

--- a/codeception/acceptance/GroupRankCest.php
+++ b/codeception/acceptance/GroupRankCest.php
@@ -1,0 +1,74 @@
+<?php
+
+/*
+ * This file is part of CustomerGroupRank
+ *
+ * Copyright(c) Akira Kurozumi <info@a-zumi.net>
+ *
+ * https://a-zumi.net
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+/**
+ * 会員グループランク管理のE2Eテスト
+ *
+ * @group plugin
+ * @group customer-group-rank
+ */
+class GroupRankCest
+{
+    public function _before(AcceptanceTester $I): void
+    {
+        $I->loginAsAdmin();
+    }
+
+    public function 会員グループ一覧ページが表示される(AcceptanceTester $I): void
+    {
+        $I->wantTo('会員グループ一覧ページが表示されることを確認する');
+
+        $I->goToGroupManagePage();
+        $I->see('会員グループ管理');
+    }
+
+    public function 会員グループにランク条件を設定できる(AcceptanceTester $I): void
+    {
+        $I->wantTo('会員グループにランク条件（購入回数・購入金額）を設定できることを確認する');
+
+        // 会員グループ編集ページに移動（ID=1のグループ）
+        $I->goToGroupEditPage(1);
+
+        // 購入回数を入力
+        $I->fillField('input[name="group[buyTimes]"]', '5');
+
+        // 購入金額を入力
+        $I->fillField('input[name="group[buyTotal]"]', '10000');
+
+        // 保存
+        $I->click('登録');
+
+        // 成功メッセージを確認
+        $I->see('保存しました');
+    }
+
+    public function 会員グループに送料無料条件を設定できる(AcceptanceTester $I): void
+    {
+        $I->wantTo('会員グループに送料無料条件を設定できることを確認する');
+
+        // 会員グループ編集ページに移動（ID=1のグループ）
+        $I->goToGroupEditPage(1);
+
+        // 送料無料条件（税込み金額）を入力
+        $I->fillField('input[name="group[deliveryFreeAmount]"]', '5000');
+
+        // 送料無料条件（数量）を入力
+        $I->fillField('input[name="group[deliveryFreeQuantity]"]', '3');
+
+        // 保存
+        $I->click('登録');
+
+        // 成功メッセージを確認
+        $I->see('保存しました');
+    }
+}


### PR DESCRIPTION
## Summary
CodeceptionによるE2Eテスト環境をセットアップしました。

## 追加ファイル
- `codeception.yml` - メイン設定ファイル
- `codeception/acceptance.suite.yml` - E2Eテスト設定（WebDriver/Chrome）
- `codeception/_support/AcceptanceTester.php` - テスターヘルパー
  - `loginAsAdmin()` - 管理者ログイン
  - `loginAsMember()` - 会員ログイン
  - `goToGroupManagePage()` - 会員グループ管理ページに移動
  - `goToGroupEditPage()` - 会員グループ編集ページに移動
- `codeception/acceptance/GroupRankCest.php` - E2Eテスト
  - 会員グループ一覧ページ表示
  - ランク条件設定
  - 送料無料条件設定
- `.github/workflows/e2e.yaml` - GitHub Actions E2Eワークフロー

## テスト実行方法
```bash
# EC-CUBEルートディレクトリで
cd app/Plugin/CustomerGroupRank42
../../../vendor/bin/codecept run acceptance
```

## Test plan
- [ ] ローカルでE2Eテストを実行
- [ ] GitHub Actionsでテストが動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)