### PR TITLE
fix: ランク判定で他プラグインが割り当てたグループを消さない

### DIFF
--- a/Resource/config/services_test.yaml
+++ b/Resource/config/services_test.yaml
@@ -1,3 +1,12 @@
 services:
-  Plugin\CustomerGroupRank42\Service\Rank\Context:
-    public: true
+    # ここでサービスを再定義すると自動設定は引き継がれない。_defaults を省くと
+    # autowire / autoconfigure が無効になり、コンストラクタ引数が注入されず、
+    # タグも付かなくなる。テスト環境でだけ機能が無効になり、本番は正常に
+    # 動くため気付けない。
+    _defaults:
+        autowire: true
+        autoconfigure: true
+
+    # 単体テストがコンテナから直接取得するため public にする。
+    Plugin\CustomerGroupRank42\Service\Rank\Context:
+        public: true

--- a/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessor.php
+++ b/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessor.php
@@ -36,8 +36,16 @@ class GroupDeliveryFreePreprocessor implements ItemHolderPreprocessor
             return;
         }
 
+        // 条件が設定された最初のグループで判定する（会員グループ価格アドオンと
+        // 同じ「並び順で最初に見つかったもの」の考え方）。所属グループの反復順は
+        // 並び順を保証しないため、ここで優先度順（sortNo 昇順）に並べ替える。
+        $groups = $Customer->getGroups()->toArray();
+        usort($groups, function (Group $a, Group $b) {
+            return $a->getSortNo() <=> $b->getSortNo();
+        });
+
         /** @var Group $group */
-        foreach ($Customer->getGroups() as $group) {
+        foreach ($groups as $group) {
             $deliveryFreeAmount = $group->getDeliveryFreeAmount();
             $deliveryFreeQuantity = $group->getDeliveryFreeQuantity();
 

--- a/Service/Rank/Rank.php
+++ b/Service/Rank/Rank.php
@@ -32,8 +32,20 @@ class Rank implements RankInterface
      */
     public function apply(Customer $customer): void
     {
-        // 会員グループをクリアする
-        $customer->getGroups()->clear();
+        // ランク管理対象の会員グループだけを外す。
+        //
+        // 以前は所属グループを全て消していたが、購入実績の条件を持たない
+        // グループは検索条件（buyTimes/buyTotal の比較）に決して一致しないため、
+        // 会員登録アドオンや管理画面で割り当てたグループがログインのたびに
+        // 失われ、二度と戻らなかった。会員グループは価格・閲覧可否・配送・
+        // 支払方法を左右するので、ランクが管理していないものは触らない。
+        /** @var Group $group */
+        foreach ($customer->getGroups()->toArray() as $group) {
+            if ($this->isRankGroup($group)) {
+                $customer->removeGroup($group);
+                $group->removeCustomer($customer);
+            }
+        }
 
         // 対象の会員グループが見つかったら登録
         $groups = $this->getGroups($customer);
@@ -41,7 +53,20 @@ class Rank implements RankInterface
             /** @var Group $group */
             $group = $groups->first();
             $customer->addGroup($group);
+            $group->addCustomer($customer);
         }
+    }
+
+    /**
+     * ランクが管理するグループか。
+     *
+     * 購入回数・購入金額のいずれかが設定されていればランク用とみなす。
+     * どちらも未設定のグループは購入実績では到達できないため、ランクの
+     * 管理外（手動で割り当てるもの）として扱う。
+     */
+    protected function isRankGroup(Group $group): bool
+    {
+        return null !== $group->getBuyTimes() || null !== $group->getBuyTotal();
     }
 
     /**

--- a/Tests/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessorTest.php
+++ b/Tests/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessorTest.php
@@ -124,11 +124,12 @@ class GroupDeliveryFreePreprocessorTest extends TestCase
         }
     }
 
-    private function createMockGroup(?float $deliveryFreeAmount, ?float $deliveryFreeQuantity): Group
+    private function createMockGroup(?float $deliveryFreeAmount, ?float $deliveryFreeQuantity, int $sortNo = 0): Group
     {
         $group = $this->createMock(Group::class);
         $group->method('getDeliveryFreeAmount')->willReturn($deliveryFreeAmount);
         $group->method('getDeliveryFreeQuantity')->willReturn($deliveryFreeQuantity);
+        $group->method('getSortNo')->willReturn($sortNo);
 
         return $group;
     }
@@ -166,5 +167,38 @@ class GroupDeliveryFreePreprocessorTest extends TestCase
         $Order->method('getShippings')->willReturn(new ArrayCollection([$Shipping]));
 
         return $Order;
+    }
+
+    /**
+     * 複数のグループに条件があるときは、優先度が上のグループで判定する。
+     *
+     * 所属グループの反復順は並び順を保証しないため、意図的に逆順で渡す。
+     * 並べ替えが無いと、優先度が下のグループ（厳しい条件）で判定されてしまう。
+     */
+    public function test複数グループでは優先度が上のグループの条件で判定する(): void
+    {
+        // 優先度が下（sortNo が大きい）＝厳しい条件
+        $low = $this->createMockGroup(10000, null, 2);
+        // 優先度が上（sortNo が小さい）＝ゆるい条件
+        $high = $this->createMockGroup(1000, null, 1);
+
+        // わざと優先度の低い方を先に並べる
+        $customer = $this->createMockCustomer([$low, $high]);
+        $order = $this->createMockOrder($customer, 5000);
+
+        $context = $this->createMock(PurchaseContext::class);
+        $this->preprocessor->process($order, $context);
+
+        foreach ($order->getShippings() as $Shipping) {
+            foreach ($Shipping->getOrderItems() as $Item) {
+                if ($Item->getProcessorName() == DeliveryFeePreprocessor::class) {
+                    self::assertSame(
+                        0,
+                        (int) $Item->getQuantity(),
+                        '優先度が上のグループの条件で判定されていません'
+                    );
+                }
+            }
+        }
     }
 }

--- a/Tests/Service/Rank/RankTest.php
+++ b/Tests/Service/Rank/RankTest.php
@@ -101,4 +101,73 @@ class RankTest extends EccubeTestCase
         self::assertCount(1, $groups);
         self::assertEquals($group1, $groups->first());
     }
+
+    /**
+     * ランク条件を持たないグループは、ランク判定で外さない。
+     *
+     * 会員登録アドオンや管理画面で割り当てたグループは購入実績の条件を
+     * 持たないため、検索条件に一致しない。以前は所属グループを全て消して
+     * いたので、ログインのたびにそれらが失われ、二度と戻らなかった。
+     */
+    public function test手動で割り当てたグループはランク判定で外れない(): void
+    {
+        $manual = $this->createGroup('手動割当グループ');
+        $manual->setSortNo(1);
+
+        $rank = $this->createGroup('ゴールド');
+        $rank->setBuyTimes(1);
+        $rank->setBuyTotal(1000);
+        $rank->setSortNo(2);
+
+        $customer = $this->createCustomer();
+        $customer->setBuyTimes(5);
+        $customer->setBuyTotal(50000);
+        $customer->addGroup($manual);
+        $manual->addCustomer($customer);
+
+        $this->entityManager->flush();
+
+        $this->context->apply($customer);
+        $this->entityManager->flush();
+
+        $names = $this->entityManager->find(Customer::class, $customer->getId())
+            ->getGroups()
+            ->map(function ($group) {
+                return $group->getName();
+            })
+            ->toArray();
+
+        self::assertContains($manual->getName(), $names, '手動で割り当てたグループが失われています');
+        self::assertContains($rank->getName(), $names, 'ランクのグループが設定されていません');
+    }
+
+    /**
+     * 条件に一致するランクが無くても、手動で割り当てたグループは残る。
+     */
+    public function test購入実績が無くても手動で割り当てたグループは残る(): void
+    {
+        $manual = $this->createGroup('手動割当グループ');
+
+        $rank = $this->createGroup('ゴールド');
+        $rank->setBuyTimes(10);
+        $rank->setBuyTotal(100000);
+
+        $customer = $this->createCustomer();
+        $customer->addGroup($manual);
+        $manual->addCustomer($customer);
+
+        $this->entityManager->flush();
+
+        $this->context->apply($customer);
+        $this->entityManager->flush();
+
+        $names = $this->entityManager->find(Customer::class, $customer->getId())
+            ->getGroups()
+            ->map(function ($group) {
+                return $group->getName();
+            })
+            ->toArray();
+
+        self::assertSame([$manual->getName()], $names, '手動で割り当てたグループが失われています');
+    }
 }


### PR DESCRIPTION
## 何が起きていたか

`Rank::apply()` がログインのたびに **所属グループを全消去** していました。

```php
$customer->getGroups()->clear();
```

購入実績の条件を持たないグループは検索条件（`buyTimes <= x OR buyTotal <= x`）に **決して一致しません**（NULL 比較のため）。そのため、会員登録アドオンや承認制アドオン、管理画面で割り当てたグループは初回ログインで失われ、二度と戻りませんでした。

実測（修正前）— フロントから普通にログインしただけで再現します。

| ケース | ログイン前 | ログイン後 |
| --- | --- | --- |
| 法人グループ + ランク条件に合致 | 法人グループ | ゴールド（法人が消失） |
| 法人グループ + 購入実績なし | 法人グループ | **(なし)** |

会員グループは会員グループ価格、限定商品・限定カテゴリの閲覧可否、配送方法・支払方法の選択肢を左右するため、影響範囲が広い問題です。

## 変更内容

### 1. ランクが管理するグループだけを外す

購入回数か購入金額が設定されているグループのみをランク管理対象とみなし、それ以外は触りません。

修正後は `法人グループ, ゴールド` のように共存します。

### 2. 送料無料条件を優先度順で判定する

送料無料条件は「条件が設定された最初のグループ」で判定しますが、`$customer->getGroups()` の反復順は並び順を保証しません。1 の変更で複数グループが共存するようになるため、優先度順（`sortNo` 昇順）に並べ替えてから判定します。会員グループ価格アドオンと同じ考え方です。

### 3. `services_test.yaml` に `_defaults` を追加

`_defaults` が無いためテスト環境でだけ `Context` の `autowire` / `autoconfigure` が落ちていました。現状 `Context` はコンストラクタ引数もタグも持たないため実害はありませんが、増えた瞬間にテストだけ壊れる形なので直しておきます。

## 検証

- 手動で割り当てたグループが残ること、購入実績が無くても残ることを検証するテストを追加
- 複数グループのとき優先度が上のグループの条件で送料無料を判定することを検証するテストを追加（意図的に逆順で渡す）
- いずれも **元の実装に戻すと失敗する** ことを確認（ミューテーション検証）
- 実ログイン経由でも修正後は `法人グループ, ゴールド` になることを確認
- プラグイン全 36 件が成功、PHPStan もエラーなし

## 補足

既存の `test既存のグループがクリアされてから新しいグループが設定される` はランク条件を持つグループ同士のケースなので、修正後もそのまま通ります。

🤖 Generated with [Claude Code](https://claude.com/claude-code)