### PR TITLE
test: エンティティ拡張のプロキシをテスト側でも読み込む

### DIFF
--- a/Tests/EntityProxyLoader.php
+++ b/Tests/EntityProxyLoader.php
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * This file is part of CustomerGroupRank
+ *
+ * Copyright(c) Akira Kurozumi <info@a-zumi.net>
+ *
+ * https://a-zumi.net
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Plugin\CustomerGroupRank42\Tests;
+
+/**
+ * エンティティ拡張（@EntityExtension）のプロキシを読み込む。
+ *
+ * app/proxy/entity 以下のプロキシは元のソースツリーをそのまま写した階層に
+ * 置かれるため（例: app/proxy/entity/src/Eccube/Entity/Customer.php）、
+ * composer.json の PSR-4 では解決されない。本体は Kernel の起動時に
+ * require_once でまとめて読み込んでいる。
+ *
+ * そのためカーネルを起動しない単体テストでは拡張前のクラスが読まれ、
+ * 拡張で足したメソッド（Customer::hasGroups() や Group::getBuyTimes() など）が
+ * 存在しない状態になる。テストを単体で実行したときだけ「モックできない
+ * メソッド」で落ち、スイート全体では他のテストが先にカーネルを起動するので
+ * 通る、という気付きにくい形になる。
+ */
+final class EntityProxyLoader
+{
+    /**
+     * @return void
+     */
+    public static function load(): void
+    {
+        static $loaded = false;
+
+        if ($loaded) {
+            return;
+        }
+        $loaded = true;
+
+        // 拡張前のクラスが先に読まれていた場合にプロキシを重ねると、
+        // クラス重複で致命的エラーになるため何もしない。
+        if (
+            class_exists(\Eccube\Entity\Customer::class, false)
+            || class_exists(\Plugin\CustomerGroup42\Entity\Group::class, false)
+        ) {
+            return;
+        }
+
+        $dir = __DIR__.'/../../../proxy/entity';
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $files = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS)
+        );
+
+        foreach ($files as $file) {
+            if ($file->isFile() && 'php' === $file->getExtension()) {
+                require_once $file->getRealPath();
+            }
+        }
+    }
+}

--- a/Tests/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessorTest.php
+++ b/Tests/Service/PurchaseFlow/Processor/GroupDeliveryFreePreprocessorTest.php
@@ -22,11 +22,23 @@ use Eccube\Service\PurchaseFlow\Processor\DeliveryFeePreprocessor;
 use Eccube\Service\PurchaseFlow\PurchaseContext;
 use PHPUnit\Framework\TestCase;
 use Plugin\CustomerGroup42\Entity\Group;
+use Plugin\CustomerGroupRank42\Tests\EntityProxyLoader;
 use Plugin\CustomerGroupRank42\Service\PurchaseFlow\Processor\GroupDeliveryFreePreprocessor;
 
 class GroupDeliveryFreePreprocessorTest extends TestCase
 {
     private $preprocessor;
+
+    public static function setUpBeforeClass(): void
+    {
+        parent::setUpBeforeClass();
+
+        // Group はプラグインが拡張したエンティティで、そのプロキシは
+        // カーネル起動時にしか読み込まれない。このテストはカーネルを
+        // 起動しないため、単体で実行すると拡張前のクラスが読まれて
+        // モックを組めなくなる。
+        EntityProxyLoader::load();
+    }
 
     protected function setUp(): void
     {

--- a/Tests/bootstrap.php
+++ b/Tests/bootstrap.php
@@ -19,3 +19,7 @@ if (file_exists($envFile)) {
         ->usePutenv()
         ->bootEnv($envFile);
 }
+
+// プラグインのエンティティ拡張は PSR-4 で解決されないため明示的に読み込む。
+// 詳細は EntityProxyLoader を参照。
+Plugin\CustomerGroupRank42\Tests\EntityProxyLoader::load();


### PR DESCRIPTION
## 何が起きていたか

`GroupDeliveryFreePreprocessorTest` を **ファイル単体で実行すると全件エラー** になります。

```
MethodCannotBeConfiguredException: Trying to configure method "hasGroups"
which cannot be configured because it does not exist...
```

スイート全体で実行すると通るため、気付きにくい状態でした。

## 原因

`app/proxy/entity` 以下のプロキシは、元のソースツリーをそのまま写した階層に置かれます。

```
app/proxy/entity/src/Eccube/Entity/Customer.php
app/proxy/entity/app/Plugin/CustomerGroup42/Entity/Group.php
```

一方 `composer.json` の PSR-4 は `Eccube\Entity\` を `app/proxy/entity` に向けているだけなので、この階層は解決されません。`Plugin\` に至っては `app/Plugin` を指したままです。本体は `Kernel` の起動時に `require_once` でまとめて読み込んでいます。

そのため **カーネルを起動しない単体テストでは拡張前のクラスが読まれ**、拡張で足したメソッド（`Customer::hasGroups()`、`Group::getDeliveryFreeAmount()` など）が存在しません。スイート全体では他のテストが先にカーネルを起動するので通ってしまいます。

## 変更内容

プロキシを読み込む `Tests\EntityProxyLoader` を追加し、2か所から呼びます。

- `Tests/bootstrap.php` … プラグインの `phpunit.xml.dist` で実行する場合
- 対象のテストクラスの `setUpBeforeClass()` … 本体の phpunit 設定で実行する場合（bootstrap を通らないため）

拡張前のクラスが既に読み込まれている場合は、クラス重複による致命的エラーを避けるため何もしません。

## 検証

修正前後で、全テストファイルを単独実行して比較しました。

| | 修正前 | 修正後 |
| --- | --- | --- |
| `GroupDeliveryFreePreprocessorTest` 単体 | ERRORS（6件） | OK（6件） |
| その他8ファイル 単体 | OK | OK |
| スイート全体 | OK（36件） | OK（36件） |

PHPStan もエラーなしです。

## 補足

この挙動は、本セッションで別の不具合を切り分ける際に実装の問題と誤認しかけた箇所です。単体実行での失敗が実装起因に見えるため、切り分けを誤らせやすいと判断して修正しました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)
