### PR TITLE
docs: 開発ガイドを実装の注意点まで広げる

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,34 +1,137 @@
-# CustomerGroupRank42
+# CLAUDE.md
 
-会員グループ管理プラグインのアドオン。購入実績に基づく会員ランク自動登録と、グループごとの送料無料条件を提供。
+このファイルは Claude Code がこのリポジトリを理解するためのガイドです。
+仕様と使い方は README.md を参照してください。ここでは実装上の注意を扱います。
 
-## 依存プラグイン
-- CustomerGroup42（会員グループ管理プラグイン）
+## プラグイン概要
 
-## 実装機能
+EC-CUBE 4.2 / 4.3 用。購入実績に基づく会員ランクの自動登録と、会員グループごとの
+送料無料条件を提供するアドオン。`CustomerGroup42` に依存する。
 
-### 会員ランク自動登録
-- 購入回数・購入金額に基づいて会員グループを自動登録
-- ログイン時に条件判定を実行
-- 複数条件マッチ時は優先度最上位のグループを適用
-- RankInterfaceによるカスタマイズ可能
+## ディレクトリ構造
 
-### 会員グループごとの送料無料条件
-- グループ単位で送料無料の金額条件を設定可能
-- グループ単位で送料無料の数量条件を設定可能
-- PurchaseFlowで送料計算後に適用
+```
+CustomerGroupRank42/
+├── Bundle/                         # バンドル定義（コンパイラパスの登録）
+├── DependencyInjection/Compiler/   # ランク判定クラスの収集
+├── Entity/                         # Group への EntityExtension
+├── Form/Extension/Admin/           # 会員グループ編集画面の入力欄
+├── Repository/QueryCustomizer/     # 会員グループ検索への条件追加
+├── Resource/config/                # services.yaml / services.php / bundles.php
+├── Security/EventListener/         # ログイン時のトリガー
+├── Service/Rank/                   # ランク判定
+├── Service/PurchaseFlow/Processor/ # 送料無料条件
+└── Tests/
+```
 
 ## 主要クラス
 
 | クラス | 役割 |
 |--------|------|
-| `Service\Rank\Context` | ランク判定の実行コンテキスト |
-| `Service\Rank\Rank` | デフォルトのランク判定ロジック |
-| `Service\Rank\RankInterface` | ランク判定のカスタマイズ用インターフェース |
-| `Service\PurchaseFlow\Processor\GroupDeliveryFreePreprocessor` | グループ別送料無料処理 |
-| `Security\EventListener\LoginListener` | ログイン時のランク判定トリガー |
-| `Entity\GroupTrait` | Groupエンティティの拡張（buyTimes, buyTotal, deliveryFreeAmount, deliveryFreeQuantity） |
+| `Service\Rank\Context` | ランク判定の実行コンテキスト（タグで収集した判定クラスを順に適用） |
+| `Service\Rank\Rank` | 既定のランク判定 |
+| `Service\Rank\RankInterface` | カスタマイズ用インターフェース |
+| `Security\EventListener\LoginListener` | ログイン時に判定を実行 |
+| `Repository\QueryCustomizer\GroupSearchCustomizer` | 購入実績による絞り込み条件を追加 |
+| `Service\PurchaseFlow\Processor\GroupDeliveryFreePreprocessor` | グループ別の送料無料 |
+| `Entity\GroupTrait` | `buyTimes` / `buyTotal` / `deliveryFreeAmount` / `deliveryFreeQuantity` |
 
-## 対応バージョン
-- EC-CUBE 4.2 / 4.3
-- PHP 7.4+
+## ランク判定の仕組み
+
+`plugin.customer.group.rank` タグの付いたサービスが `RankPass` によって `Context` に
+集められ、priority の大きい順に `apply()` される。既定の `Rank` は priority 100。
+
+カスタマイズは `RankInterface` を実装して同じタグを付ける。README にあるとおり
+priority を 99 以下にすると既定の後に走る。
+
+判定は `LoginListener` が `security.interactive_login` で起動する。**ログイン時にしか
+走らない。** 購入直後にランクを上げたい場合は別途トリガーが必要。
+
+## 実装上の注意
+
+### ランクが管理していないグループを消さないこと
+
+**これが本プラグインで最も重要な注意点。**
+
+以前の `Rank::apply()` は `$customer->getGroups()->clear()` で所属グループを全消去して
+いた。購入実績の条件を持たないグループは検索条件（`buyTimes <= x OR buyTotal <= x`）に
+**決して一致しない**（NULL 比較のため）ので、会員登録アドオンや承認制アドオン、
+管理画面で割り当てたグループがログインのたびに失われ、二度と戻らなかった。
+
+会員グループは会員グループ価格、限定商品・限定カテゴリの閲覧可否、配送方法・
+支払方法の選択肢を左右する。影響が広いので、**ランクが管理するグループ
+（`buyTimes` か `buyTotal` が設定されているもの）だけを外す**こと。
+
+`Tests/Service/Rank/RankTest` の「手動で割り当てたグループは〜」がこの不変条件を
+守っている。
+
+### 所属グループの反復順は並び順を保証しない
+
+送料無料条件は「条件が設定された最初のグループ」で判定するが、
+`$customer->getGroups()` の反復順は会員グループの並び順（`sortNo`）と一致しない。
+判定前に `sortNo` 昇順へ並べ替えること。会員グループ価格アドオンと同じ考え方。
+
+### 送料無料の適用は数量を 0 にする
+
+`DeliveryFeePreprocessor` が作った送料明細を探し、数量を 0 にすることで無料化する。
+明細自体は残す。`services.php` で **`DeliveryFeePreprocessor`（送料計算）の後、
+`DeliveryFeeFreeByShippingPreprocessor` の前**に実行されるよう順序を指定している。
+
+EC-CUBE 4.3 以降はタグの priority（750）で、4.2 は `ArrayCollection` で順序を明示する。
+`services.php` が `Constant::VERSION` で分岐しているのはこのため。片方だけ直すと
+どちらかのバージョンで順序が崩れる。
+
+### 単体テストはエンティティ拡張のプロキシを読み込むこと
+
+`app/proxy/entity` 以下のプロキシは元のソースツリーを写した階層に置かれるため、
+`composer.json` の PSR-4 では解決されない。本体は `Kernel` の起動時に `require_once`
+でまとめて読み込んでいる。
+
+そのため**カーネルを起動しない単体テストでは拡張前のクラスが読まれ**、拡張で
+足したメソッド（`Customer::hasGroups()` や `Group::getBuyTimes()` など）が存在しない。
+スイート全体では他のテストが先にカーネルを起動するので通ってしまい、
+**ファイル単体で実行したときだけ落ちる**。
+
+`Tests\EntityProxyLoader` がこれを吸収する。モックでエンティティを扱う
+テストクラスでは `setUpBeforeClass()` から呼ぶこと。
+
+### services_test.yaml で autoconfigure を落とさないこと
+
+`Resource/config/services_test.yaml` はテスト環境でのみ読み込まれる
+（`Kernel::configureContainer()`）。サービスを再定義すると自動設定が引き継がれない
+ため `_defaults` で `autowire` / `autoconfigure` を明示する。
+
+`Context` は現状コンストラクタ引数もタグも持たないため実害は出ないが、増えた瞬間に
+テスト環境だけ壊れる。姉妹プラグインでは実際に機能が丸ごと無効になっていた。
+
+### 管理画面の入力欄はテンプレートスニペットで差し込む
+
+`Event.php` が `@CustomerGroup42/admin/Customer/Group/edit.twig` にスニペットを
+追加している。親プラグインのテンプレートのパスが変わると表示されなくなるので、
+親を更新したときは表示を確認すること。
+
+## テスト
+
+```bash
+# EC-CUBE ルートから
+vendor/bin/phpunit app/Plugin/CustomerGroupRank42/Tests
+
+# プラグイン単体の設定で
+vendor/bin/phpunit -c app/Plugin/CustomerGroupRank42/phpunit.xml.dist
+```
+
+`Tests/Web/` 配下は `WebTestCase` 系なので、**`APP_ENV=test` が実行プロセスの
+環境変数に入っている必要がある**。`phpunit.xml` の `<server>` 指定は `$_ENV` /
+`$_SERVER` の `APP_ENV` に負ける。
+
+`Tests/Resource/Config/ServicesPhpTest` には EC-CUBE 4.2 専用のテストが含まれ、
+4.3 環境ではスキップされる。スキップ4件は正常。
+
+**実行ユーザーは一貫させること。** root と www-data を混ぜると `var/cache/<env>` が
+root 所有で作られ、次に www-data で実行したときに全ページ 500 になる。起きたら
+`chown -R www-data:www-data var/cache var/log` で直る。
+
+## 命名規則
+
+- コミットメッセージ: `type: 説明`（例: `fix: バグ修正`, `docs: ドキュメント更新`）
+- ブランチ名: `type/description`（例: `fix/bug-name`）


### PR DESCRIPTION
## 背景

CLAUDE.md が機能一覧とクラス一覧だけ（34行）で、**実装を触るときに何に気を付ければ
よいか**が分かりませんでした。

## 特に重要な内容

### ランクが管理していないグループを消さないこと

以前の `Rank::apply()` は所属グループを全消去していました。購入実績の条件を持たない
グループは検索条件に決して一致しないため、会員登録アドオンや承認制アドオン、
管理画面で割り当てたグループが**ログインのたびに失われ、二度と戻りません**でした。

会員グループは価格・閲覧可否・配送・支払方法を左右するため影響が広く、再発させないよう
筆頭に記載しています。

### その他

- 所属グループの反復順は並び順を保証しないため、送料無料の判定前に `sortNo` 昇順へ並べ替える
- 送料無料の適用順序は EC-CUBE 4.2 と 4.3 で指定方法が異なる（`services.php` がバージョンで分岐）。片方だけ直すと順序が崩れる
- **単体テストはエンティティ拡張のプロキシを読み込む必要がある**。PSR-4 で解決されないため、カーネルを起動しないテストはファイル単体実行だけ落ちる
- ランク判定は `security.interactive_login` で起動するため、**ログイン時にしか走らない**
- 管理画面の入力欄は親プラグインのテンプレートへスニペットで差し込んでいる

## 確認したこと

記載内容は実装で裏を取っています。

- ランク判定サービスのタグと priority（`plugin.customer.group.rank`, 100）
- スニペットの差し込み先テンプレートが存在すること
- 4.2 専用テストのスキップ4件が正常であること

🤖 Generated with [Claude Code](https://claude.com/claude-code)