### PR TITLE
chore: バージョンを 4.3.1 に更新する

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ec-cube/customergrouprank42",
-    "version": "4.3.0",
+    "version": "4.3.1",
     "description": "会員グループ管理::会員ランク管理アドオン",
     "type": "eccube-plugin",
     "require": {


### PR DESCRIPTION
## v4.3.1 リリース準備

`composer.json` の version を `4.3.1` に更新します。

マージ後に GitHub Release を作成し、パッケージング用ワークフローで tar.gz を生成します。

### リリースノート案

### 不具合修正
- **ログインのたびに、他のプラグインや管理画面で割り当てた会員グループが失われていました。** ランクが管理する会員グループ（購入回数・購入金額を設定したもの）だけを対象にするよう修正しました

  会員登録アドオンや承認制アドオンで割り当てた会員グループ、管理画面から手動で割り当てた会員グループが、会員の初回ログインで消える状態でした。**すでに失われた割り当ては復元されません。**

- 送料無料条件を、会員グループの並び順で最初に条件が設定されているグループで判定するようにしました
- 送料無料の適用順序を修正しました（送料計算の後、他の送料無料処理の前）

### ドキュメント
- 開発者向けの CLAUDE.md に、実装上の注意点を追加しました
